### PR TITLE
Add Agent to the operations so we can mock up Authorization checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ $ AWS_REGION=localstack AWS_ACCESS_KEY_ID=999999 AWS_SECRET_KEY=1231 ./tacod
 
 Then you can interact with it using `curl`:
 ```shell
-$ curl -H "Content-Type: application/json" -d@examples/request.json http://localhost:8080/v1/resource
+$ curl -H "Content-Type: application/json" \
+ -H "On-Behalf-Of: lmcrae@stanford.edu" \
+ -d@examples/request.json http://localhost:8080/v1/resource
 ```
 
 it will return a response like:
@@ -89,18 +91,22 @@ it will return a response like:
 Then you can use the returned identifier to retrieve the original:
 
 ```shell
-$ curl -H "Content-Type: application/json"  http://localhost:8080/v1/resource/fe1f66a9-5285-4b28-8240-0482c8fff6c7
+$ curl -H "Content-Type: application/json" \
+ -H "On-Behalf-Of: lmcrae@stanford.edu" \
+ http://localhost:8080/v1/resource/fe1f66a9-5285-4b28-8240-0482c8fff6c7
 ```
 
 You can then update the resource with a **PATCH** request:
 ```shell
-$ curl -X PATCH -H "Content-Type: application/json" -d@examples/update_request.json http://localhost:8080/v1/resource/fe1f66a9-5285-4b28-8240-0482c8fff6c7
+$ curl -X PATCH -H "Content-Type: application/json" \ -d@examples/update_request.json \
+-H "On-Behalf-Of: lmcrae@stanford.edu" \ http://localhost:8080/v1/resource/fe1f66a9-5285-4b28-8240-0482c8fff6c7
 ```
 
 Create an uploaded file by doing:
 
 ```shell
-$ curl -F "upload=@myfile.pdf;type=application/pdf" http://localhost:8080/v1/file
+$ curl -H "On-Behalf-Of: lmcrae@stanford.edu" \
+-F "upload=@myfile.pdf;type=application/pdf" http://localhost:8080/v1/file
 ```
 
 ## Testing
@@ -138,7 +144,7 @@ There appears to be no best way to handle specification-based re-generation of t
 ```shell
 $ git rm -rf generated/
 $ mkdir generated
-$ swagger generate server -t generated --exclude-main
+$ swagger generate server -t generated --exclude-main --principal authorization.Agent
 ```
 
 ### To generate the validator ```

--- a/authorization/agent.go
+++ b/authorization/agent.go
@@ -1,0 +1,8 @@
+package authorization
+
+// Agent represents a user or machine account that uses the api
+type Agent struct {
+	// Identifier is typically an email address of the form: lmcrae@stanford.edu
+	// but it could also include special identifiers, e.g.: labs@stanford
+	Identifier string
+}

--- a/authorization/authorization.go
+++ b/authorization/authorization.go
@@ -1,0 +1,28 @@
+package authorization
+
+import (
+	"github.com/sul-dlss-labs/taco/datautils"
+)
+
+// Service can answer queries about whether an agent can take a specific action
+type Service interface {
+	CanCreateResourceOfType(string) bool
+	CanRetrieveResource(*datautils.Resource) bool
+}
+
+type dummyAuthorizationService struct {
+	agent *Agent
+}
+
+// NewService creates a new instance of the authorization service
+func NewService(agent *Agent) Service {
+	return &dummyAuthorizationService{agent: agent}
+}
+
+func (d *dummyAuthorizationService) CanCreateResourceOfType(resourceType string) bool {
+	return d.agent.Identifier == "lmcrae@stanford.edu"
+}
+
+func (d *dummyAuthorizationService) CanRetrieveResource(res *datautils.Resource) bool {
+	return d.agent.Identifier == "lmcrae@stanford.edu"
+}

--- a/generated/restapi/configure_taco.go
+++ b/generated/restapi/configure_taco.go
@@ -11,12 +11,13 @@ import (
 	middleware "github.com/go-openapi/runtime/middleware"
 	graceful "github.com/tylerb/graceful"
 
+	"github.com/sul-dlss-labs/taco/authorization"
 	"github.com/sul-dlss-labs/taco/generated/restapi/operations"
 )
 
 // This file is safe to edit. Once it exists it will not be overwritten
 
-//go:generate swagger generate server --target ../generated --name  --spec ../swagger.json --exclude-main
+//go:generate swagger generate server --target ../generated --name  --spec ../swagger.json --principal authorization.Agent --exclude-main
 
 func configureFlags(api *operations.TacoAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }
@@ -38,22 +39,33 @@ func configureAPI(api *operations.TacoAPI) http.Handler {
 
 	api.JSONProducer = runtime.JSONProducer()
 
+	// Applies when the "On-Behalf-Of" header is set
+	api.RemoteUserAuth = func(token string) (*authorization.Agent, error) {
+		return nil, errors.NotImplemented("api key auth (RemoteUser) On-Behalf-Of from header param [On-Behalf-Of] has not yet been implemented")
+	}
+
+	// Set your custom authorizer if needed. Default one is security.Authorized()
+	// Expected interface runtime.Authorizer
+	//
+	// Example:
+	// api.APIAuthorizer = security.Authorized()
+
 	api.DeleteResourceHandler = operations.DeleteResourceHandlerFunc(func(params operations.DeleteResourceParams) middleware.Responder {
 		return middleware.NotImplemented("operation .DeleteResource has not yet been implemented")
 	})
-	api.DepositFileHandler = operations.DepositFileHandlerFunc(func(params operations.DepositFileParams) middleware.Responder {
+	api.DepositFileHandler = operations.DepositFileHandlerFunc(func(params operations.DepositFileParams, principal *authorization.Agent) middleware.Responder {
 		return middleware.NotImplemented("operation .DepositFile has not yet been implemented")
 	})
-	api.DepositResourceHandler = operations.DepositResourceHandlerFunc(func(params operations.DepositResourceParams) middleware.Responder {
+	api.DepositResourceHandler = operations.DepositResourceHandlerFunc(func(params operations.DepositResourceParams, principal *authorization.Agent) middleware.Responder {
 		return middleware.NotImplemented("operation .DepositResource has not yet been implemented")
 	})
-	api.GetProcessStatusHandler = operations.GetProcessStatusHandlerFunc(func(params operations.GetProcessStatusParams) middleware.Responder {
+	api.GetProcessStatusHandler = operations.GetProcessStatusHandlerFunc(func(params operations.GetProcessStatusParams, principal *authorization.Agent) middleware.Responder {
 		return middleware.NotImplemented("operation .GetProcessStatus has not yet been implemented")
 	})
 	api.HealthCheckHandler = operations.HealthCheckHandlerFunc(func(params operations.HealthCheckParams) middleware.Responder {
 		return middleware.NotImplemented("operation .HealthCheck has not yet been implemented")
 	})
-	api.RetrieveResourceHandler = operations.RetrieveResourceHandlerFunc(func(params operations.RetrieveResourceParams) middleware.Responder {
+	api.RetrieveResourceHandler = operations.RetrieveResourceHandlerFunc(func(params operations.RetrieveResourceParams, principal *authorization.Agent) middleware.Responder {
 		return middleware.NotImplemented("operation .RetrieveResource has not yet been implemented")
 	})
 	api.UpdateResourceHandler = operations.UpdateResourceHandlerFunc(func(params operations.UpdateResourceParams) middleware.Responder {

--- a/generated/restapi/embedded_spec.go
+++ b/generated/restapi/embedded_spec.go
@@ -32,6 +32,11 @@ func init() {
   "paths": {
     "/file": {
       "post": {
+        "security": [
+          {
+            "RemoteUser": []
+          }
+        ],
         "description": "Deposits a new File (binary) into SDR. Will return the SDR identifier for the File resource (aka the metadata object generated and persisted for management of the provided binary).",
         "consumes": [
           "multipart/form-data"
@@ -92,6 +97,11 @@ func init() {
     },
     "/resource": {
       "post": {
+        "security": [
+          {
+            "RemoteUser": []
+          }
+        ],
         "description": "Deposits a new resource (Collection, Digital Repository Object, File [metadata only] or subclass of those) into SDR. Will return the SDR identifier for the resource.",
         "consumes": [
           "application/json",
@@ -140,6 +150,11 @@ func init() {
     },
     "/resource/{ID}": {
       "get": {
+        "security": [
+          {
+            "RemoteUser": []
+          }
+        ],
         "description": "Retrieves the metadata (as JSON-LD following our SDR3 MAP v.1) for an existing TACO resource (Collection, Digital Repository Object, File metadata object [not binary] or subclass of those). The resource is identified by the TACO identifier.",
         "produces": [
           "application/json"
@@ -266,6 +281,11 @@ func init() {
     },
     "/status/{ID}": {
       "get": {
+        "security": [
+          {
+            "RemoteUser": []
+          }
+        ],
         "description": "Get the processing status and history for a resource.",
         "produces": [
           "application/json"
@@ -366,6 +386,13 @@ func init() {
     },
     "ResourceResponse": {
       "type": "object"
+    }
+  },
+  "securityDefinitions": {
+    "RemoteUser": {
+      "type": "apiKey",
+      "name": "On-Behalf-Of",
+      "in": "header"
     }
   }
 }`))

--- a/generated/restapi/operations/deposit_file.go
+++ b/generated/restapi/operations/deposit_file.go
@@ -9,19 +9,20 @@ import (
 	"net/http"
 
 	middleware "github.com/go-openapi/runtime/middleware"
+	"github.com/sul-dlss-labs/taco/authorization"
 )
 
 // DepositFileHandlerFunc turns a function with the right signature into a deposit file handler
-type DepositFileHandlerFunc func(DepositFileParams) middleware.Responder
+type DepositFileHandlerFunc func(DepositFileParams, *authorization.Agent) middleware.Responder
 
 // Handle executing the request and returning a response
-func (fn DepositFileHandlerFunc) Handle(params DepositFileParams) middleware.Responder {
-	return fn(params)
+func (fn DepositFileHandlerFunc) Handle(params DepositFileParams, principal *authorization.Agent) middleware.Responder {
+	return fn(params, principal)
 }
 
 // DepositFileHandler interface for that can handle valid deposit file params
 type DepositFileHandler interface {
-	Handle(DepositFileParams) middleware.Responder
+	Handle(DepositFileParams, *authorization.Agent) middleware.Responder
 }
 
 // NewDepositFile creates a new http.Handler for the deposit file operation
@@ -48,12 +49,25 @@ func (o *DepositFile) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 	var Params = NewDepositFileParams()
 
+	uprinc, aCtx, err := o.Context.Authorize(r, route)
+	if err != nil {
+		o.Context.Respond(rw, r, route.Produces, route, err)
+		return
+	}
+	if aCtx != nil {
+		r = aCtx
+	}
+	var principal *authorization.Agent
+	if uprinc != nil {
+		principal = uprinc.(*authorization.Agent) // this is really a authorization.Agent, I promise
+	}
+
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
-	res := o.Handler.Handle(Params) // actually handle the request
+	res := o.Handler.Handle(Params, principal) // actually handle the request
 
 	o.Context.Respond(rw, r, route.Produces, route, res)
 

--- a/generated/restapi/operations/deposit_resource.go
+++ b/generated/restapi/operations/deposit_resource.go
@@ -9,19 +9,20 @@ import (
 	"net/http"
 
 	middleware "github.com/go-openapi/runtime/middleware"
+	"github.com/sul-dlss-labs/taco/authorization"
 )
 
 // DepositResourceHandlerFunc turns a function with the right signature into a deposit resource handler
-type DepositResourceHandlerFunc func(DepositResourceParams) middleware.Responder
+type DepositResourceHandlerFunc func(DepositResourceParams, *authorization.Agent) middleware.Responder
 
 // Handle executing the request and returning a response
-func (fn DepositResourceHandlerFunc) Handle(params DepositResourceParams) middleware.Responder {
-	return fn(params)
+func (fn DepositResourceHandlerFunc) Handle(params DepositResourceParams, principal *authorization.Agent) middleware.Responder {
+	return fn(params, principal)
 }
 
 // DepositResourceHandler interface for that can handle valid deposit resource params
 type DepositResourceHandler interface {
-	Handle(DepositResourceParams) middleware.Responder
+	Handle(DepositResourceParams, *authorization.Agent) middleware.Responder
 }
 
 // NewDepositResource creates a new http.Handler for the deposit resource operation
@@ -48,12 +49,25 @@ func (o *DepositResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 	var Params = NewDepositResourceParams()
 
+	uprinc, aCtx, err := o.Context.Authorize(r, route)
+	if err != nil {
+		o.Context.Respond(rw, r, route.Produces, route, err)
+		return
+	}
+	if aCtx != nil {
+		r = aCtx
+	}
+	var principal *authorization.Agent
+	if uprinc != nil {
+		principal = uprinc.(*authorization.Agent) // this is really a authorization.Agent, I promise
+	}
+
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
-	res := o.Handler.Handle(Params) // actually handle the request
+	res := o.Handler.Handle(Params, principal) // actually handle the request
 
 	o.Context.Respond(rw, r, route.Produces, route, res)
 

--- a/generated/restapi/operations/retrieve_resource.go
+++ b/generated/restapi/operations/retrieve_resource.go
@@ -9,19 +9,20 @@ import (
 	"net/http"
 
 	middleware "github.com/go-openapi/runtime/middleware"
+	"github.com/sul-dlss-labs/taco/authorization"
 )
 
 // RetrieveResourceHandlerFunc turns a function with the right signature into a retrieve resource handler
-type RetrieveResourceHandlerFunc func(RetrieveResourceParams) middleware.Responder
+type RetrieveResourceHandlerFunc func(RetrieveResourceParams, *authorization.Agent) middleware.Responder
 
 // Handle executing the request and returning a response
-func (fn RetrieveResourceHandlerFunc) Handle(params RetrieveResourceParams) middleware.Responder {
-	return fn(params)
+func (fn RetrieveResourceHandlerFunc) Handle(params RetrieveResourceParams, principal *authorization.Agent) middleware.Responder {
+	return fn(params, principal)
 }
 
 // RetrieveResourceHandler interface for that can handle valid retrieve resource params
 type RetrieveResourceHandler interface {
-	Handle(RetrieveResourceParams) middleware.Responder
+	Handle(RetrieveResourceParams, *authorization.Agent) middleware.Responder
 }
 
 // NewRetrieveResource creates a new http.Handler for the retrieve resource operation
@@ -48,12 +49,25 @@ func (o *RetrieveResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 	var Params = NewRetrieveResourceParams()
 
+	uprinc, aCtx, err := o.Context.Authorize(r, route)
+	if err != nil {
+		o.Context.Respond(rw, r, route.Produces, route, err)
+		return
+	}
+	if aCtx != nil {
+		r = aCtx
+	}
+	var principal *authorization.Agent
+	if uprinc != nil {
+		principal = uprinc.(*authorization.Agent) // this is really a authorization.Agent, I promise
+	}
+
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
-	res := o.Handler.Handle(Params) // actually handle the request
+	res := o.Handler.Handle(Params, principal) // actually handle the request
 
 	o.Context.Respond(rw, r, route.Produces, route, res)
 

--- a/handlers/deposit_file_test.go
+++ b/handlers/deposit_file_test.go
@@ -25,6 +25,7 @@ func TestCreateFileHappyPath(t *testing.T) {
 
 	r.POST(filePath).
 		SetHeader(gofight.H{
+			"On-Behalf-Of": "lmcrae@stanford.edu",
 			"Content-Type": contentType,
 		}).
 		SetBody(body).
@@ -43,6 +44,7 @@ func TestCreateFileWrongContentType(t *testing.T) {
 	r := gofight.New()
 	r.POST(filePath).
 		SetHeader(gofight.H{
+			"On-Behalf-Of": "lmcrae@stanford.edu",
 			"Content-Type": "application/xml",
 		}).
 		SetBody(``).
@@ -66,6 +68,33 @@ func TestCreateFileWrongContentType(t *testing.T) {
 // 			})
 // }
 
+func TestCreateFileNoApiKey(t *testing.T) {
+	r := gofight.New()
+	r.POST(filePath).
+		SetHeader(gofight.H{
+			"Content-Type": contentType,
+		}).
+		SetBody(body).
+		Run(handler(nil, nil, nil),
+			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+				assert.Equal(t, http.StatusUnauthorized, r.Code)
+			})
+}
+
+func TestCreateFileNoPermissions(t *testing.T) {
+	r := gofight.New()
+	r.POST(filePath).
+		SetHeader(gofight.H{
+			"On-Behalf-Of": "blalbrit@stanford.edu", // The dummy authZ service is set to only allow lmcrae
+			"Content-Type": contentType,
+		}).
+		SetBody(body).
+		Run(handler(nil, nil, nil),
+			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+				assert.Equal(t, http.StatusUnauthorized, r.Code)
+			})
+}
+
 func TestCreateFileFailure(t *testing.T) {
 	r := gofight.New()
 	repo := NewMockDatabase(nil)
@@ -74,6 +103,7 @@ func TestCreateFileFailure(t *testing.T) {
 		func() {
 			r.POST(filePath).
 				SetHeader(gofight.H{
+					"On-Behalf-Of": "lmcrae@stanford.edu",
 					"Content-Type": contentType,
 				}).
 				SetBody(body).
@@ -90,6 +120,7 @@ func TestCreateFileResourceFailure(t *testing.T) {
 
 			r.POST(filePath).
 				SetHeader(gofight.H{
+					"On-Behalf-Of": "lmcrae@stanford.edu",
 					"Content-Type": contentType,
 				}).
 				SetBody(body).

--- a/handlers/deposit_resource.go
+++ b/handlers/deposit_resource.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/sul-dlss-labs/taco/authorization"
 	"github.com/sul-dlss-labs/taco/datautils"
 	"github.com/sul-dlss-labs/taco/db"
 	"github.com/sul-dlss-labs/taco/generated/models"
@@ -32,13 +33,19 @@ type depositResource struct {
 	identifierService identifier.Service
 }
 
-// Handle the delete entry request
-func (d *depositResource) Handle(params operations.DepositResourceParams) middleware.Responder {
+// Handle the create resource request
+func (d *depositResource) Handle(params operations.DepositResourceParams, agent *authorization.Agent) middleware.Responder {
 	resource := datautils.NewResource(params.Payload.(map[string]interface{}))
 
 	if errors := d.validator.ValidateResource(resource); errors != nil {
 		return operations.NewDepositResourceUnprocessableEntity().
 			WithPayload(&models.ErrorResponse{Errors: *errors})
+	}
+
+	authService := authorization.NewService(agent)
+	if !authService.CanCreateResourceOfType(resource.Type()) {
+		log.Printf("Agent %s is not permitted to create a resource of type %s", agent, resource.Type())
+		return operations.NewDepositResourceUnauthorized()
 	}
 
 	resourceID, err := d.identifierService.Mint()

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/go-openapi/loads"
+	"github.com/sul-dlss-labs/taco/authorization"
 	"github.com/sul-dlss-labs/taco/db"
 	"github.com/sul-dlss-labs/taco/generated/restapi"
 	"github.com/sul-dlss-labs/taco/generated/restapi/operations"
@@ -16,6 +17,9 @@ import (
 // BuildAPI create new service API
 func BuildAPI(database db.Database, stream streaming.Stream, storage storage.Storage, identifierService identifier.Service) *operations.TacoAPI {
 	api := operations.NewTacoAPI(swaggerSpec())
+	api.RemoteUserAuth = func(identifier string) (*authorization.Agent, error) {
+		return &authorization.Agent{Identifier: identifier}, nil
+	}
 	api.RetrieveResourceHandler = NewRetrieveResource(database)
 	api.DepositResourceHandler = NewDepositResource(database, stream, depositValidator(database), identifierService)
 	api.UpdateResourceHandler = NewUpdateResource(database, stream, updateValidator(database))

--- a/swagger.json
+++ b/swagger.json
@@ -12,11 +12,21 @@
   "host": "sdr.dlss.stanford.edu",
   "basePath": "/v1",
   "schemes": ["http"],
+  "securityDefinitions" : {
+    "RemoteUser" : {
+     "type": "apiKey",
+     "in" : "header",
+     "name" : "On-Behalf-Of"
+    }
+  },
   "paths": {
     "/resource": {
       "post": {
         "summary": "Deposit New TACO Resource.",
         "description": "Deposits a new resource (Collection, Digital Repository Object, File [metadata only] or subclass of those) into SDR. Will return the SDR identifier for the resource.",
+        "security" : [
+          { "RemoteUser": [] }
+        ],
         "operationId": "depositResource",
         "consumes": ["application/json", "application/json+ld"],
         "produces": ["application/json"],
@@ -58,6 +68,9 @@
       "get": {
         "summary": "Retrieve TACO Resource Metadata.",
         "description": "Retrieves the metadata (as JSON-LD following our SDR3 MAP v.1) for an existing TACO resource (Collection, Digital Repository Object, File metadata object [not binary] or subclass of those). The resource is identified by the TACO identifier.",
+        "security" : [
+          { "RemoteUser": [] }
+        ],
         "operationId": "retrieveResource",
         "produces": ["application/json"],
         "parameters": [{
@@ -168,6 +181,9 @@
       "post": {
         "summary": "Deposit New File (binary).",
         "description": "Deposits a new File (binary) into SDR. Will return the SDR identifier for the File resource (aka the metadata object generated and persisted for management of the provided binary).",
+        "security" : [
+          { "RemoteUser": [] }
+        ],
         "operationId": "depositFile",
         "consumes": ["multipart/form-data"],
         "produces": ["application/json"],
@@ -201,6 +217,9 @@
       "get": {
         "summary": "Resource Processing Status.",
         "description": "Get the processing status and history for a resource.",
+        "security" : [
+          { "RemoteUser": [] }
+        ],
         "operationId": "getProcessStatus",
         "produces": ["application/json"],
         "parameters": [{

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -51,7 +51,7 @@ func TestCreateResource(t *testing.T) {
 	}
 
 	setupTest().Post("/v1/resource").
-		SetHeader("Foo", "Bar").
+		SetHeader("On-Behalf-Of", "lmcrae@stanford.edu").
 		JSON(postData).
 		Expect(t).
 		Status(201).
@@ -61,6 +61,7 @@ func TestCreateResource(t *testing.T) {
 		Done()
 
 	setupTest().Get(fmt.Sprintf("/v1/resource/%s", id)).
+		SetHeader("On-Behalf-Of", "lmcrae@stanford.edu").
 		Expect(t).
 		Status(200).
 		Type("json").
@@ -83,7 +84,7 @@ func TestUpdateResource(t *testing.T) {
 	}
 
 	setupTest().Post("/v1/resource").
-		SetHeader("Foo", "Bar").
+		SetHeader("On-Behalf-Of", "lmcrae@stanford.edu").
 		JSON(postData).
 		Expect(t).
 		Status(201).
@@ -104,6 +105,7 @@ func TestUpdateResource(t *testing.T) {
 	}
 
 	setupTest().Patch(fmt.Sprintf("/v1/resource/%s", id)).
+		SetHeader("On-Behalf-Of", "lmcrae@stanford.edu").
 		SetHeader("Content-Type", "application/json").
 		JSON(patchData).
 		Expect(t).
@@ -114,6 +116,7 @@ func TestUpdateResource(t *testing.T) {
 		Done()
 
 	setupTest().Get(fmt.Sprintf("/v1/resource/%s", id)).
+		SetHeader("On-Behalf-Of", "lmcrae@stanford.edu").
 		Expect(t).
 		Status(200).
 		Type("json").
@@ -129,7 +132,7 @@ func TestCreateFile(t *testing.T) {
 	file := multipart.FormFile{Name: "upload", Reader: strings.NewReader("data")}
 	files := []multipart.FormFile{file}
 	setupTest().Post("/v1/file").
-		SetHeader("Foo", "Bar").
+		SetHeader("On-Behalf-Of", "lmcrae@stanford.edu").
 		Files(files).
 		Expect(t).
 		Status(201).
@@ -139,6 +142,7 @@ func TestCreateFile(t *testing.T) {
 		Done()
 
 	setupTest().Get(fmt.Sprintf("/v1/resource/%s", id)).
+		SetHeader("On-Behalf-Of", "lmcrae@stanford.edu").
 		Expect(t).
 		Status(200).
 		Type("json").


### PR DESCRIPTION
This changes the API spec to specify that a sunet ID is required when
making a request.

This changes the generated code such that we can get the principal for
the request and validate it in the handlers.

See #44 
Fixes #79
