### PR TITLE
Remove go get from the Readme and favor dep ensure.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install Dependencies
           command: |
             go get -u github.com/golang/dep/cmd/dep
-            dep ensure
+            dep ensure -vendor-only
       - run:
           name: Run Tests
           command: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ $ go get github.com/sul-dlss-labs/taco
 ```
 4. Handle dependencies with the Go Dep package:
     * Install Go Dep via `brew install dep` then `brew upgrade dep`.
-    * If your project's `Gopkg.toml` has not yet been populated (i.e. there should be libraries not commented out), you need to add an inferred list of your dependencies by running `dep init`.
-    * If your project has that, make sure your dependencies are synced via running `dep ensure`.
-    * If you need to add a new dependency, run `dep ensure -add github.com/pkg/errors`. This should add the dependency and put the new dependency in your `Gopkg.*` files.
+    * Make sure your dependencies are synced via running `dep ensure`.
+    * When you add a new dependency add an include in the code and then run `dep ensure`. This will add the dependency to your `Gopkg.lock` file.
 
 ## Running the Go Code locally without a build
 
@@ -45,7 +44,7 @@ $ docker run -p 8080:8080 taco
 ### Build for the local OS
 ```shell
 % cd cmd/tacod
-% go get -t
+% dep ensure -vendor-only
 % go build -o tacod main.go
 ```
 


### PR DESCRIPTION
This ammends existing instructions for dep usage to something that is
easier to manage as there is no need for the `dep ensure -add` step.

If you do `dep ensure -add` then you also need to make sure you manually
remove the entries from Gopkg.toml when you stop using a library.
Using the dep feature where it introspects your includes is a less
error prone way to deal with this.

Ref #75