### PR TITLE
Refactor load of configuration from environment

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -247,12 +247,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/spf13/viper"
-  packages = ["."]
-  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
-  version = "v1.0.0"
-
-[[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -66,10 +66,6 @@
   version = "1.3.0"
 
 [[constraint]]
-  name = "github.com/spf13/viper"
-  version = "1.0.0"
-
-[[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.0"
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ $ go get github.com/sul-dlss-labs/taco
     * If your project has that, make sure your dependencies are synced via running `dep ensure`.
     * If you need to add a new dependency, run `dep ensure -add github.com/pkg/errors`. This should add the dependency and put the new dependency in your `Gopkg.*` files.
 
+5. Localstack and Environment Variables
+    * Local development depends on [localstack](https://github.com/localstack/localstack) to mock the AWS environment.
+    * Environment Variables for development default to [localstack](https://github.com/localstack/localstack), if these are run on non-standard ports, review the environment variables in [config](config/config.go)
+     
 ## Running the Go Code locally without a build
 
 ```shell

--- a/cmd/tacod/main.go
+++ b/cmd/tacod/main.go
@@ -2,13 +2,9 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
-	"os"
 
-	"github.com/spf13/viper"
 	"github.com/sul-dlss-labs/taco"
-	"github.com/sul-dlss-labs/taco/config"
 	"github.com/sul-dlss-labs/taco/generated/restapi"
 	"github.com/sul-dlss-labs/taco/handlers"
 )
@@ -16,15 +12,8 @@ import (
 var portFlag = flag.Int("port", 8080, "Port to run this service on")
 
 func main() {
-	mode := os.Getenv("TACO_ENV")
-	if mode == "" {
-		mode = "development"
-	}
 
-	configFile := fmt.Sprintf("../../config/%s.yaml", mode)
-	config.Init(configFile)
-
-	rt, err := taco.NewRuntime(viper.GetViper())
+	rt, err := taco.NewRuntime()
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ func NewConfig() *Config {
 	return &Config{
 		AWS_Region: aws_region(),
 		DB_Endpoint: db_endpoint(),
-		Disable_SSL: disable_ssl(), // os.Getenv("DISABLE_SSL"),
+		Disable_SSL: disable_ssl(),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,35 +1,54 @@
 package config
 
 import (
-	"fmt"
+	"os"
 	"log"
-	"path/filepath"
-
-	"github.com/spf13/viper"
 )
 
-// Init is an exported method that takes the environment starts the viper
-// (external lib) and returns the configuration struct.
-func Init(cfgFile string) {
-	if cfgFile != "" { // enable ability to specify config file via flag
-		viper.SetConfigFile(cfgFile)
-	} else {
-		viper.SetConfigName(".taco") // name of config file (without extension)
-		viper.AddConfigPath("$HOME") // adding home directory as first search path
-	}
-	viper.AutomaticEnv() // read in environment variables that match
-	// If a config file is found, read it in.
-	err := viper.ReadInConfig()
-	if err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
-	} else {
-		log.Printf("Error no config file: %s", err)
+type Config struct {
+    AWS_Region	string
+		DB_Endpoint string
+		Disable_SSL bool
+}
+
+func NewConfig() *Config {
+	return &Config{
+		AWS_Region: aws_region(),
+		DB_Endpoint: db_endpoint(),
+		Disable_SSL: disable_ssl(), // os.Getenv("DISABLE_SSL"),
 	}
 }
 
-func relativePath(basedir string, path *string) {
-	p := *path
-	if p != "" && p[0] != '/' {
-		*path = filepath.Join(basedir, p)
+func aws_region() string {
+	var region string
+	region = os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "localstack"
+		log.Printf("AWS_REGION: Using default [localstack].")
+	}
+	log.Printf("AWS_REGION: Found setting [%s]", region)
+	return region
+}
+
+func db_endpoint() string {
+	var endpoint string
+	endpoint = os.Getenv("DB_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "localhost:4569"
+		log.Printf("DB_ENDPOINT: Using default [localhost:4569].")
+	}
+	log.Printf("DB_ENDPOINT: Found setting [%s]", endpoint)
+	return endpoint
+}
+
+func disable_ssl() bool {
+	var disablessl string
+  disablessl = os.Getenv("DISABLE_SSL")
+	if (disablessl == "FALSE" || disablessl == "false") {
+		log.Printf("DISABLE_SSL: Found setting [false].")
+		return false
+	} else {
+		log.Printf("DISABLE_SSL: Using default [true].")
+		return true
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,29 +6,29 @@ import (
 )
 
 type Config struct {
-	AWS_Dynamo_Region string
-	Dynamo_Db         string
-	Disable_SSL       bool
-	Table_Name        string
+	AWS_Region          string
+	Dynamo_Db           string
+	Dynamo_Disable_SSL  bool
+	Resource_Table_Name string
 }
 
 func NewConfig() *Config {
 	return &Config{
-		AWS_Dynamo_Region: aws_dynamo_region(),
-		Dynamo_Db:         dynamo_db(),
-		Disable_SSL:       disable_ssl(),
-		Table_Name:        table_name(),
+		AWS_Region:          aws_region(),
+		Dynamo_Db:           dynamo_db(),
+		Dynamo_Disable_SSL:  dynamo_disable_ssl(),
+		Resource_Table_Name: resource_table_name(),
 	}
 }
 
-func aws_dynamo_region() string {
+func aws_region() string {
 	var region string
-	region = os.Getenv("AWS_DYNAMO_REGION")
+	region = os.Getenv("AWS_REGION")
 	if region == "" {
 		region = "localstack"
-		log.Printf("AWS_DYNAMO_REGION: Using default [localstack].")
+		log.Printf("AWS_REGION: Using default [localstack].")
 	}
-	log.Printf("AWS_DYNAMO_REGION: Found setting [%s]", region)
+	log.Printf("AWS_REGION: Found setting [%s]", region)
 	return region
 }
 
@@ -37,30 +37,30 @@ func dynamo_db() string {
 	db = os.Getenv("DYNAMO_DB")
 	if db == "" {
 		db = "localhost:4569"
-		log.Printf("DB_ENDPOINT: Using default [localhost:4569].")
+		log.Printf("DYNAMO_DB: Using default [localhost:4569].")
 	}
-	log.Printf("DB_ENDPOINT: Found setting [%s]", db)
+	log.Printf("DYNAMO_DB: Found setting [%s]", db)
 	return db
 }
 
-func disable_ssl() bool {
+func dynamo_disable_ssl() bool {
 	var disablessl string
-	disablessl = os.Getenv("DISABLE_SSL")
+	disablessl = os.Getenv("DYNAMODB_DISABLE_SSL")
 	if disablessl == "FALSE" || disablessl == "false" {
-		log.Printf("DISABLE_SSL: Found setting [false].")
+		log.Printf("DYNAMODB_DISABLE_SSL: Found setting [false].")
 		return false
 	} else {
-		log.Printf("DISABLE_SSL: Using default [true].")
+		log.Printf("DYNAMODB_DISABLE_SSL: Using default [true].")
 		return true
 	}
 }
 
-func table_name() string {
+func resource_table_name() string {
 	var tablename string
-	tablename = os.Getenv("TABLE_NAME")
+	tablename = os.Getenv("RESOURCE_TABLE_NAME")
 	if tablename == "" {
 		tablename = "resources"
-		log.Printf("TABLE_NAME: Using default [resources].")
+		log.Printf("RESOURCE_TABLE_NAME: Using default [resources].")
 	}
 	return tablename
 }

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,7 @@ import (
 
 type Config struct {
 	AWS_Region          string
-	Dynamo_Db           string
+	Dynamo_Db_Endpoint  string
 	Dynamo_Disable_SSL  bool
 	Resource_Table_Name string
 }
@@ -15,7 +15,7 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		AWS_Region:          aws_region(),
-		Dynamo_Db:           dynamo_db(),
+		Dynamo_Db_Endpoint:  dynamo_db_endpoint(),
 		Dynamo_Disable_SSL:  dynamo_disable_ssl(),
 		Resource_Table_Name: resource_table_name(),
 	}
@@ -32,14 +32,14 @@ func aws_region() string {
 	return region
 }
 
-func dynamo_db() string {
+func dynamo_db_endpoint() string {
 	var db string
-	db = os.Getenv("DYNAMO_DB")
+	db = os.Getenv("DYNAMO_DB_ENDPOINT")
 	if db == "" {
 		db = "localhost:4569"
-		log.Printf("DYNAMO_DB: Using default [localhost:4569].")
+		log.Printf("DYNAMO_DB_ENDPOINT: Using default [localhost:4569].")
 	}
-	log.Printf("DYNAMO_DB: Found setting [%s]", db)
+	log.Printf("DYNAMO_DB_ENDPOINT: Found setting [%s]", db)
 	return db
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -7,14 +7,14 @@ import (
 
 type Config struct {
     AWS_Region	string
-		DB_Endpoint string
+		Dynamo_Db string
 		Disable_SSL bool
 }
 
 func NewConfig() *Config {
 	return &Config{
 		AWS_Region: aws_region(),
-		DB_Endpoint: db_endpoint(),
+		Dynamo_Db: dynamo_db(),
 		Disable_SSL: disable_ssl(),
 	}
 }
@@ -30,15 +30,15 @@ func aws_region() string {
 	return region
 }
 
-func db_endpoint() string {
-	var endpoint string
-	endpoint = os.Getenv("DB_ENDPOINT")
-	if endpoint == "" {
-		endpoint = "localhost:4569"
+func dynamo_db() string {
+	var db string
+	db = os.Getenv("DYNAMO_DB")
+	if db == "" {
+		db = "localhost:4569"
 		log.Printf("DB_ENDPOINT: Using default [localhost:4569].")
 	}
-	log.Printf("DB_ENDPOINT: Found setting [%s]", endpoint)
-	return endpoint
+	log.Printf("DB_ENDPOINT: Found setting [%s]", db)
+	return db
 }
 
 func disable_ssl() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -6,29 +6,29 @@ import (
 )
 
 type Config struct {
-	AWS_Region  string
-	Dynamo_Db   string
-	Disable_SSL bool
-	Table_Name  string
+	AWS_Dynamo_Region string
+	Dynamo_Db         string
+	Disable_SSL       bool
+	Table_Name        string
 }
 
 func NewConfig() *Config {
 	return &Config{
-		AWS_Region:  aws_region(),
-		Dynamo_Db:   dynamo_db(),
-		Disable_SSL: disable_ssl(),
-		Table_Name:  table_name(),
+		AWS_Dynamo_Region: aws_dynamo_region(),
+		Dynamo_Db:         dynamo_db(),
+		Disable_SSL:       disable_ssl(),
+		Table_Name:        table_name(),
 	}
 }
 
-func aws_region() string {
+func aws_dynamo_region() string {
 	var region string
-	region = os.Getenv("AWS_REGION")
+	region = os.Getenv("AWS_DYNAMO_REGION")
 	if region == "" {
 		region = "localstack"
-		log.Printf("AWS_REGION: Using default [localstack].")
+		log.Printf("AWS_DYNAMO_REGION: Using default [localstack].")
 	}
-	log.Printf("AWS_REGION: Found setting [%s]", region)
+	log.Printf("AWS_DYNAMO_REGION: Found setting [%s]", region)
 	return region
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,21 +1,23 @@
 package config
 
 import (
-	"os"
 	"log"
+	"os"
 )
 
 type Config struct {
-    AWS_Region	string
-		Dynamo_Db string
-		Disable_SSL bool
+	AWS_Region  string
+	Dynamo_Db   string
+	Disable_SSL bool
+	Table_Name  string
 }
 
 func NewConfig() *Config {
 	return &Config{
-		AWS_Region: aws_region(),
-		Dynamo_Db: dynamo_db(),
+		AWS_Region:  aws_region(),
+		Dynamo_Db:   dynamo_db(),
 		Disable_SSL: disable_ssl(),
+		Table_Name:  table_name(),
 	}
 }
 
@@ -43,12 +45,22 @@ func dynamo_db() string {
 
 func disable_ssl() bool {
 	var disablessl string
-  disablessl = os.Getenv("DISABLE_SSL")
-	if (disablessl == "FALSE" || disablessl == "false") {
+	disablessl = os.Getenv("DISABLE_SSL")
+	if disablessl == "FALSE" || disablessl == "false" {
 		log.Printf("DISABLE_SSL: Found setting [false].")
 		return false
 	} else {
 		log.Printf("DISABLE_SSL: Using default [true].")
 		return true
 	}
+}
+
+func table_name() string {
+	var tablename string
+	tablename = os.Getenv("TABLE_NAME")
+	if tablename == "" {
+		tablename = "resources"
+		log.Printf("TABLE_NAME: Using default [resources].")
+	}
+	return tablename
 }

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,6 +1,0 @@
-db:
-  region: "localstack"
-  endpoint: "localhost:4569"
-  disable_ssl: true
-resource_repository:
-  table_name: "resources"

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -1,6 +1,0 @@
-db:
-  region: "us-east-2"
-  endpoint: "https://dynamodb.us-east-2.amazonaws.com"
-  disable_ssl: false
-resource_repository:
-  table_name: "resources"

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -1,6 +1,0 @@
-db:
-  region: "localstack"
-  endpoint: "localhost:4569"
-  disable_ssl: true
-resource_repository:
-  table_name: "resources"

--- a/db/db.go
+++ b/db/db.go
@@ -1,21 +1,22 @@
 package db
 
 import (
+	"github.com/sul-dlss-labs/taco/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/spf13/viper"
 )
 
 var db *dynamodb.DynamoDB
 
 // NewConnection creates a new connection to Dynamo using our config
-func NewConnection(c *viper.Viper) *dynamodb.DynamoDB {
+func NewConnection() *dynamodb.DynamoDB {
+	config := config.NewConfig()
 	return dynamodb.New(session.New(&aws.Config{
-		Region:      aws.String(c.GetString("db.region")),
+		Region:      aws.String(config.AWS_Region),
 		Credentials: credentials.NewEnvCredentials(),
-		Endpoint:    aws.String(c.GetString("db.endpoint")),
-		DisableSSL:  aws.Bool(c.GetBool("db.disable_ssl")),
+		Endpoint:    aws.String(config.DB_Endpoint),
+		DisableSSL:  aws.Bool(config.Disable_SSL),
 	}))
 }

--- a/db/db.go
+++ b/db/db.go
@@ -14,9 +14,9 @@ var db *dynamodb.DynamoDB
 func NewConnection() *dynamodb.DynamoDB {
 	config := config.NewConfig()
 	return dynamodb.New(session.New(&aws.Config{
-		Region:      aws.String(config.AWS_Dynamo_Region),
+		Region:      aws.String(config.AWS_Region),
 		Credentials: credentials.NewEnvCredentials(),
 		Endpoint:    aws.String(config.Dynamo_Db),
-		DisableSSL:  aws.Bool(config.Disable_SSL),
+		DisableSSL:  aws.Bool(config.Dynamo_Disable_SSL),
 	}))
 }

--- a/db/db.go
+++ b/db/db.go
@@ -16,7 +16,7 @@ func NewConnection() *dynamodb.DynamoDB {
 	return dynamodb.New(session.New(&aws.Config{
 		Region:      aws.String(config.AWS_Region),
 		Credentials: credentials.NewEnvCredentials(),
-		Endpoint:    aws.String(config.Dynamo_Db),
+		Endpoint:    aws.String(config.Dynamo_Db_Endpoint),
 		DisableSSL:  aws.Bool(config.Dynamo_Disable_SSL),
 	}))
 }

--- a/db/db.go
+++ b/db/db.go
@@ -16,7 +16,7 @@ func NewConnection() *dynamodb.DynamoDB {
 	return dynamodb.New(session.New(&aws.Config{
 		Region:      aws.String(config.AWS_Region),
 		Credentials: credentials.NewEnvCredentials(),
-		Endpoint:    aws.String(config.DB_Endpoint),
+		Endpoint:    aws.String(config.Dynamo_Db),
 		DisableSSL:  aws.Bool(config.Disable_SSL),
 	}))
 }

--- a/db/db.go
+++ b/db/db.go
@@ -1,11 +1,11 @@
 package db
 
 import (
-	"github.com/sul-dlss-labs/taco/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/sul-dlss-labs/taco/config"
 )
 
 var db *dynamodb.DynamoDB
@@ -14,7 +14,7 @@ var db *dynamodb.DynamoDB
 func NewConnection() *dynamodb.DynamoDB {
 	config := config.NewConfig()
 	return dynamodb.New(session.New(&aws.Config{
-		Region:      aws.String(config.AWS_Region),
+		Region:      aws.String(config.AWS_Dynamo_Region),
 		Credentials: credentials.NewEnvCredentials(),
 		Endpoint:    aws.String(config.Dynamo_Db),
 		DisableSSL:  aws.Bool(config.Disable_SSL),

--- a/docs/DEVELOPER_GUIDE.MD
+++ b/docs/DEVELOPER_GUIDE.MD
@@ -1,0 +1,45 @@
+# TACO Developer Guide
+
+## Adding Envirment Variables for Configuration
+
+```shell
+export YOUR_VAR='whatever'
+```
+
+### Add config and default value
+
+1. Add to the config struct definition
+```go
+type Config struct {
+    AWS_Region	string
+		DB_Endpoint string
+		Disable_SSL bool
+    Your_Var    string
+}
+```
+
+2. Load the config and default
+```go
+func your_var() string {
+	var yourvar string
+	yourvar = os.Getenv("YOUR_VAR")
+	if endpoint == "" {
+		yourvar = "Some Default Value"
+		log.Printf("YOUR_VAR: Using default [Some Default Value].")
+	}
+	log.Printf("YOUR_VAR: Found setting [%s]", yourvar)
+	return yourvar
+}
+```
+
+3. Load var into config struct
+```go
+func NewConfig() *Config {
+	return &Config{
+		AWS_Region: aws_region(),
+		DB_Endpoint: db_endpoint(),
+		Disable_SSL: disable_ssl(),
+    Your_Var: your_var(),
+	}
+}
+```

--- a/handlers/main_test.go
+++ b/handlers/main_test.go
@@ -6,10 +6,8 @@ import (
 	"testing"
 
 	"github.com/appleboy/gofight"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/sul-dlss-labs/taco"
-	"github.com/sul-dlss-labs/taco/config"
 	"github.com/sul-dlss-labs/taco/persistence"
 )
 
@@ -36,8 +34,7 @@ func (f *fakeRepository) SaveItem(resource *persistence.Resource) error {
 }
 
 func setupFakeRuntime(repo persistence.Repository) http.Handler {
-	config.Init("../config/test.yaml")
-	rt, _ := taco.NewRuntimeForRepository(viper.GetViper(), repo)
+	rt, _ := taco.NewRuntimeForRepository(repo)
 	return BuildAPI(rt).Serve(nil)
 }
 

--- a/persistence/repository.go
+++ b/persistence/repository.go
@@ -13,7 +13,7 @@ import (
 // NewRepository -- Creates a new repository
 func NewRepository(db *dynamodb.DynamoDB) (*DynamoRepository, error) {
 	config := config.NewConfig()
-	tableName := aws.String(config.Table_Name)
+	tableName := aws.String(config.Resource_Table_Name)
 	return &DynamoRepository{db: db,
 			tableName: tableName},
 		nil

--- a/persistence/repository.go
+++ b/persistence/repository.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-	"github.com/spf13/viper"
+	"github.com/sul-dlss-labs/taco/config"
 )
 
 // NewRepository -- Creates a new repository
-func NewRepository(config viper.Viper, db *dynamodb.DynamoDB) (*DynamoRepository, error) {
-	tableName := aws.String(config.GetString("resource_repository.table_name"))
-	return &DynamoRepository{config: config,
-			db:        db,
+func NewRepository(db *dynamodb.DynamoDB) (*DynamoRepository, error) {
+	config := config.NewConfig()
+	tableName := aws.String(config.Table_Name)
+	return &DynamoRepository{db: db,
 			tableName: tableName},
 		nil
 }
@@ -26,7 +26,6 @@ type Repository interface {
 
 // DynamoRepository -- The fetching object
 type DynamoRepository struct {
-	config    viper.Viper
 	db        *dynamodb.DynamoDB
 	tableName *string
 }

--- a/runtime.go
+++ b/runtime.go
@@ -1,32 +1,29 @@
 package taco
 
 import (
-	"github.com/spf13/viper"
 	"github.com/sul-dlss-labs/taco/db"
 	"github.com/sul-dlss-labs/taco/persistence"
 )
 
 // NewRuntime creates a new application level runtime that encapsulates the shared services for this application
-func NewRuntime(config *viper.Viper) (*Runtime, error) {
-	repository, err := persistence.NewRepository(*config, db.NewConnection(config))
+func NewRuntime() (*Runtime, error) {
+	repository, err := persistence.NewRepository(db.NewConnection())
 	if err != nil {
 		return nil, err
 	}
-	return NewRuntimeForRepository(config, repository)
+	return NewRuntimeForRepository(repository)
 }
 
 // NewRuntimeForRepository creates a new application level runtime that encapsulates the shared services for this application
-func NewRuntimeForRepository(config *viper.Viper, repository persistence.Repository) (*Runtime, error) {
+func NewRuntimeForRepository(repository persistence.Repository) (*Runtime, error) {
 	return &Runtime{
 		repository: repository,
-		config:     config,
 	}, nil
 }
 
 // Runtime encapsulates the shared services for this application
 type Runtime struct {
 	repository persistence.Repository
-	config     *viper.Viper
 }
 
 // Repository returns the metadata store
@@ -35,6 +32,6 @@ func (r *Runtime) Repository() persistence.Repository {
 }
 
 // Config returns the viper config for this application
-func (r *Runtime) Config() *viper.Viper {
-	return r.config
-}
+// func (r *Runtime) Config() *viper.Viper {
+//	return r.config
+// }

--- a/runtime.go
+++ b/runtime.go
@@ -30,8 +30,3 @@ type Runtime struct {
 func (r *Runtime) Repository() persistence.Repository {
 	return r.repository
 }
-
-// Config returns the viper config for this application
-// func (r *Runtime) Config() *viper.Viper {
-//	return r.config
-// }


### PR DESCRIPTION
Per design discussion, this simplifies the loading of environment variables for the configuration by removing the environment specific configuration files and dependency on the viper library (for now).

@eefahy - this is based on the examples you provided yesterday. Can you give this a once over to make sure it's the proper direction before calling it complete?

TODO:

- [x] Update readme
- [x] Remove viper from toml/lock file

Refs:

#38 