### PR TITLE
Use environment variables first, fallback to yaml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -18,6 +19,8 @@ func Init(cfgFile string) {
 		viper.AddConfigPath("$HOME") // adding home directory as first search path
 	}
 	viper.AutomaticEnv() // read in environment variables that match
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "__"))
+	viper.SetEnvPrefix("TACO")
 	// If a config file is found, read it in.
 	err := viper.ReadInConfig()
 	if err == nil {


### PR DESCRIPTION
This allows us to set:
```
TACO_DB__ENDPOINT=whatever go run main.go
```
and that variable can be accessed via:
```
config.GetString("db.endpoint")
```

This is very similar to how we manage variables in other (Ruby) projects in DLSS