### PR TITLE
Initial stub of updateResourceHandler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           background: true
       - run:
           name: wait for server
-          command: sleep 5
+          command: sleep 15
       - run:
           name: Run tests
           command: AWS_ACCESS_KEY_ID=999 AWS_SECRET_KEY=999 TACO_PORT=3000 go test -v ./...

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Then you can use the returned identifier to retrieve the original:
 $ curl -H "Content-Type: application/json"  http://localhost:8080/v1/resource/fe1f66a9-5285-4b28-8240-0482c8fff6c7
 ```
 
+You can then update the resource with a **PATCH** request:
+```shell
+$ curl -X PATCH -H "Content-Type: application/json" -d@examples/update_request.json http://localhost:8080/v1/resource/fe1f66a9-5285-4b28-8240-0482c8fff6c7
+```
+
 Create an uploaded file by doing:
 
 ```shell

--- a/examples/update_request.json
+++ b/examples/update_request.json
@@ -1,0 +1,8 @@
+{
+		"@context": "http://sdr.sul.stanford.edu/contexts/taco-base.jsonld",
+		"@type":    "http://sdr.sul.stanford.edu/models/sdr3-object.jsonld",
+		"access":   "world",
+		"label":    "My updated SDR3 resource",
+		"preserve": true,
+		"publish":  true
+}

--- a/examples/update_request.json
+++ b/examples/update_request.json
@@ -4,5 +4,6 @@
 		"access":   "world",
 		"label":    "My updated SDR3 resource",
 		"preserve": true,
-		"publish":  true
+		"publish":  true,
+		"sourceId": "bib12345678"
 }

--- a/handlers/deposit_file.go
+++ b/handlers/deposit_file.go
@@ -53,7 +53,7 @@ func (d *depositFileEntry) copyFileToStorage(id string, file runtime.File) (*str
 
 func (d *depositFileEntry) createFileResource(resourceID string, filename string) error {
 	resource := d.buildPersistableResource(resourceID, filename)
-	return d.rt.Repository().SaveItem(resource)
+	return d.rt.Repository().CreateItem(resource)
 }
 
 func (d *depositFileEntry) buildPersistableResource(resourceID string, filename string) *persistence.Resource {

--- a/handlers/deposit_resource.go
+++ b/handlers/deposit_resource.go
@@ -43,7 +43,7 @@ func (d *depositResourceEntry) Handle(params operations.DepositResourceParams) m
 
 func (d *depositResourceEntry) persistResource(resourceID string, params operations.DepositResourceParams) error {
 	resource := d.persistableResourceFromParams(resourceID, params)
-	return d.rt.Repository().SaveItem(resource)
+	return d.rt.Repository().CreateItem(resource)
 }
 
 func (d *depositResourceEntry) persistableResourceFromParams(resourceID string, params operations.DepositResourceParams) *persistence.Resource {

--- a/handlers/main_test.go
+++ b/handlers/main_test.go
@@ -28,8 +28,12 @@ func (f *fakeRepository) GetByID(id string) (*persistence.Resource, error) {
 	return nil, errors.New("not found")
 }
 
-func (f *fakeRepository) SaveItem(resource *persistence.Resource) error {
+func (f *fakeRepository) CreateItem(resource *persistence.Resource) error {
 	f.CreatedResources = append(f.CreatedResources, *resource)
+	return nil
+}
+
+func (f *fakeRepository) UpdateItem(resource *persistence.Resource) error {
 	return nil
 }
 
@@ -98,7 +102,11 @@ func (f *fakeErroringRepository) GetByID(id string) (*persistence.Resource, erro
 	return nil, errors.New("broken")
 }
 
-func (f *fakeErroringRepository) SaveItem(resource *persistence.Resource) error {
+func (f *fakeErroringRepository) CreateItem(resource *persistence.Resource) error {
+	return errors.New("broken")
+}
+
+func (f *fakeErroringRepository) UpdateItem(resource *persistence.Resource) error {
 	return errors.New("broken")
 }
 

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -17,6 +17,7 @@ func BuildAPI(rt *taco.Runtime) *operations.TacoAPI {
 	api := operations.NewTacoAPI(swaggerSpec())
 	api.RetrieveResourceHandler = NewRetrieveResource(rt)
 	api.DepositResourceHandler = NewDepositResource(rt)
+	api.UpdateResourceHandler = NewUpdateResource(rt)
 	api.DepositFileHandler = NewDepositFile(rt)
 	api.HealthCheckHandler = NewHealthCheck(rt)
 	return api

--- a/handlers/update_resource.go
+++ b/handlers/update_resource.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"log"
+
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/sul-dlss-labs/taco"
+	"github.com/sul-dlss-labs/taco/generated/models"
+	"github.com/sul-dlss-labs/taco/generated/restapi/operations"
+	"github.com/sul-dlss-labs/taco/persistence"
+)
+
+// NewDepositResource -- Accepts requests to create resource and pushes them to Kinesis.
+func NewUpdateResource(rt *taco.Runtime) operations.UpdateResourceHandler {
+	return &updateResourceEntry{rt: rt, repository: rt.Repository()}
+}
+
+type updateResourceEntry struct {
+	rt         *taco.Runtime
+	repository persistence.Repository
+}
+
+// Handle the update resource request
+func (d *updateResourceEntry) Handle(params operations.UpdateResourceParams) middleware.Responder {
+	resource, err := d.repository.GetByID(params.ID)
+
+	if err == nil {
+		if err := d.updateResource(resource.ID, params); err != nil {
+			// TODO: handle this with an error response
+			panic(err)
+		} else {
+			log.Printf("Resource Update Successful")
+		}
+
+		response := &models.ResourceResponse{ID: params.ID}
+		return operations.NewUpdateResourceOK().WithPayload(response)
+	} else if err.Error() == "not found" {
+		return operations.NewRetrieveResourceNotFound()
+	}
+	panic(err)
+}
+
+func (d *updateResourceEntry) updateResource(resourceID string, params operations.UpdateResourceParams) error {
+	resource := d.persistableResourceFromParams(resourceID, params)
+	return d.rt.Repository().UpdateItem(resource)
+}
+
+func (d *updateResourceEntry) persistableResourceFromParams(resourceID string, params operations.UpdateResourceParams) *persistence.Resource {
+	resource := &persistence.Resource{ID: resourceID}
+	resource.Access = *params.Body.Access
+	resource.AtContext = *params.Body.AtContext
+	resource.AtType = *params.Body.AtType
+	resource.Label = *params.Body.Label
+	resource.Preserve = *params.Body.Preserve
+	resource.Publish = *params.Body.Publish
+	return resource
+}

--- a/handlers/update_resource.go
+++ b/handlers/update_resource.go
@@ -45,12 +45,12 @@ func (d *updateResourceEntry) updateResource(resourceID string, params operation
 
 func (d *updateResourceEntry) persistableResourceFromParams(resourceID string, params operations.UpdateResourceParams) *persistence.Resource {
 	resource := &persistence.Resource{ID: resourceID}
-	resource.Access = *params.Body.Access
-	resource.AtContext = *params.Body.AtContext
-	resource.AtType = *params.Body.AtType
-	resource.Label = *params.Body.Label
-	resource.Preserve = *params.Body.Preserve
-	resource.Publish = *params.Body.Publish
-	resource.SourceID = *params.Body.SourceID
+	resource.Access = *params.Payload.Access
+	resource.AtContext = *params.Payload.AtContext
+	resource.AtType = *params.Payload.AtType
+	resource.Label = *params.Payload.Label
+	resource.Preserve = *params.Payload.Preserve
+	resource.Publish = *params.Payload.Publish
+	// resource.SourceID = *params.Payload.SourceID
 	return resource
 }

--- a/handlers/update_resource.go
+++ b/handlers/update_resource.go
@@ -10,23 +10,21 @@ import (
 	"github.com/sul-dlss-labs/taco/persistence"
 )
 
-// NewDepositResource -- Accepts requests to create resource and pushes them to Kinesis.
+// NewUpdateResource -- Accepts requests to update a resource.
 func NewUpdateResource(rt *taco.Runtime) operations.UpdateResourceHandler {
-	return &updateResourceEntry{rt: rt, repository: rt.Repository()}
+	return &updateResourceEntry{rt: rt}
 }
 
 type updateResourceEntry struct {
-	rt         *taco.Runtime
-	repository persistence.Repository
+	rt *taco.Runtime
 }
 
 // Handle the update resource request
 func (d *updateResourceEntry) Handle(params operations.UpdateResourceParams) middleware.Responder {
-	resource, err := d.repository.GetByID(params.ID)
+	resource, err := d.rt.Repository().GetByID(params.ID)
 
 	if err == nil {
 		if err := d.updateResource(resource.ID, params); err != nil {
-			// TODO: handle this with an error response
 			panic(err)
 		} else {
 			log.Printf("Resource Update Successful")
@@ -53,5 +51,6 @@ func (d *updateResourceEntry) persistableResourceFromParams(resourceID string, p
 	resource.Label = *params.Body.Label
 	resource.Preserve = *params.Body.Preserve
 	resource.Publish = *params.Body.Publish
+	resource.SourceID = *params.Body.SourceID
 	return resource
 }

--- a/handlers/update_resource.go
+++ b/handlers/update_resource.go
@@ -51,6 +51,6 @@ func (d *updateResourceEntry) persistableResourceFromParams(resourceID string, p
 	resource.Label = *params.Payload.Label
 	resource.Preserve = *params.Payload.Preserve
 	resource.Publish = *params.Payload.Publish
-	// resource.SourceID = *params.Payload.SourceID
+	resource.SourceID = params.Payload.SourceID
 	return resource
 }

--- a/handlers/update_resource_test.go
+++ b/handlers/update_resource_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/appleboy/gofight"
+	"github.com/stretchr/testify/assert"
+	"github.com/sul-dlss-labs/taco/persistence"
+)
+
+func TestUpdateResourceHappyPath(t *testing.T) {
+	r := gofight.New()
+	repo := mockRepo(new(persistence.Resource))
+
+	r.PATCH("/v1/resource/99").
+		SetHeader(gofight.H{"Content-Type": "application/json"}).
+		SetJSON(gofight.D{
+			"id":       "99",
+			"@context": "http://sdr.sul.stanford.edu/contexts/taco-base.jsonld",
+			"@type":    "http://sdr.sul.stanford.edu/models/sdr3-object.jsonld",
+			"access":   "world",
+			"label":    "My updated work",
+			"preserve": true,
+			"publish":  true,
+			"sourceId": "bib12345678"}).
+		Run(setupFakeRuntime().WithRepository(repo).Handler(),
+			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+				assert.Equal(t, http.StatusOK, r.Code)
+			})
+}
+
+func TestUpdateResourceNotFound(t *testing.T) {
+	r := gofight.New()
+	r.PATCH("/v1/resource/99").
+		SetHeader(gofight.H{"Content-Type": "application/json"}).
+		SetJSON(gofight.D{
+			"id":       "99",
+			"@context": "http://sdr.sul.stanford.edu/contexts/taco-base.jsonld",
+			"@type":    "http://sdr.sul.stanford.edu/models/sdr3-object.jsonld",
+			"access":   "world",
+			"label":    "My updated work",
+			"preserve": true,
+			"publish":  true,
+			"sourceId": "bib12345678"}).
+		Run(setupFakeRuntime().WithRepository(mockRepo(nil)).Handler(),
+			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+				assert.Equal(t, http.StatusNotFound, r.Code)
+			})
+}
+
+func TestUpdateResourceEmptyRequest(t *testing.T) {
+	r := gofight.New()
+	r.PATCH("/v1/resource/100").
+		Run(setupFakeRuntime().WithRepository(mockRepo(nil)).Handler(),
+			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+				assert.Equal(t, http.StatusUnprocessableEntity, r.Code)
+			})
+}

--- a/persistence/repository.go
+++ b/persistence/repository.go
@@ -20,7 +20,8 @@ func NewDynamoRepository(config *config.Config, db *dynamodb.DynamoDB) *DynamoRe
 // Repository the interface for the metadata repository
 type Repository interface {
 	GetByID(string) (*Resource, error)
-	SaveItem(*Resource) error
+	CreateItem(*Resource) error
+	UpdateItem(*Resource) error
 }
 
 // DynamoRepository -- The fetching object
@@ -30,7 +31,7 @@ type DynamoRepository struct {
 }
 
 // SaveItem perist the resource in dynamo db
-func (h DynamoRepository) SaveItem(resource *Resource) error {
+func (h DynamoRepository) CreateItem(resource *Resource) error {
 	row, err := dynamodbattribute.MarshalMap(resource)
 
 	if err != nil {
@@ -77,4 +78,25 @@ func (h DynamoRepository) GetByID(id string) (*Resource, error) {
 		return nil, errors.New("not found")
 	}
 	return resource, nil
+}
+
+// UpdateItem - Replaces an existing resource in the repository
+func (h DynamoRepository) UpdateItem(resource *Resource) error {
+	row, err := dynamodbattribute.MarshalMap(resource)
+
+	if err != nil {
+		return err
+	}
+
+	input := &dynamodb.PutItemInput{
+		Item:      row,
+		TableName: h.tableName,
+	}
+
+	_, err = h.db.PutItem(input)
+
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/persistence/repository_test.go
+++ b/persistence/repository_test.go
@@ -16,7 +16,7 @@ func TestSaveAndRetrieve(t *testing.T) {
 	config := config.NewConfig()
 	repo := NewDynamoRepository(config, db.NewConnection(config))
 	resource := &Resource{ID: id, Label: "Hello world"}
-	err := repo.SaveItem(resource)
+	err := repo.CreateItem(resource)
 	assert.Nil(t, err)
 	item, err := repo.GetByID(id)
 	assert.Nil(t, err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -32,7 +33,6 @@ const resourceSchema = `{
 }`
 
 var id string
-var label string
 
 func TestCreateResource(t *testing.T) {
 	if testing.Short() {
@@ -118,11 +118,6 @@ func TestUpdateResource(t *testing.T) {
 		Type("json").
 		AssertFunc(assertUpdatedResourceResponse).
 		Done()
-
-		// minimal integration test for label (the only field changed in our update statement)
-	if label != patchData["label"] {
-		t.Errorf("Updated label not applied.")
-	}
 }
 
 func TestCreateFile(t *testing.T) {
@@ -179,9 +174,9 @@ func assertResourceResponse(res *http.Response, req *http.Request) error {
 func assertUpdatedResourceResponse(res *http.Response, req *http.Request) error {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(res.Body)
-	jsonID, _ := jsonparser.GetString(buf.Bytes(), "id")
 	jsonLabel, _ := jsonparser.GetString(buf.Bytes(), "label")
-	id = jsonID
-	label = jsonLabel
+	if jsonLabel != "My updated SDR3 resource" {
+		return errors.New("UpdateResource failure")
+	}
 	return nil
 }


### PR DESCRIPTION
This is currently a stub copied mostly from retrieve resource and deposit resource. A few updates are outstanding.


- [x] document how to update a resource in the readme
- [x] return correct response
- [x] write update resource to dynamodb
- [x] unit test (happy path and error paths)
- [x] integration test
- [x] handles not found error
- [x] handles database write error

Note: As this is currently a stub, it is implemented via `PutItem` which replaces the existing item. There may be outstanding questions about handling record updates during processing that will necessitate using the more complex `UpdateItem`, which could be implemented in a follow up PR.

Fix #47 