### PR TITLE
Use dependency injection

### DIFF
--- a/cmd/tacod/main.go
+++ b/cmd/tacod/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/sul-dlss-labs/taco"
+	"github.com/sul-dlss-labs/taco/config"
 	"github.com/sul-dlss-labs/taco/generated/restapi"
 	"github.com/sul-dlss-labs/taco/handlers"
 )
@@ -12,8 +13,7 @@ import (
 var portFlag = flag.Int("port", 8080, "Port to run this service on")
 
 func main() {
-
-	rt, err := taco.NewRuntime()
+	rt, err := taco.NewRuntime(config.NewConfig())
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/persistence/repository.go
+++ b/persistence/repository.go
@@ -11,8 +11,7 @@ import (
 )
 
 // NewRepository -- Creates a new repository
-func NewRepository(db *dynamodb.DynamoDB) (*DynamoRepository, error) {
-	config := config.NewConfig()
+func NewRepository(config *config.Config, db *dynamodb.DynamoDB) (*DynamoRepository, error) {
 	tableName := aws.String(config.ResourceTableName)
 	return &DynamoRepository{db: db,
 			tableName: tableName},

--- a/runtime.go
+++ b/runtime.go
@@ -1,13 +1,14 @@
 package taco
 
 import (
+	"github.com/sul-dlss-labs/taco/config"
 	"github.com/sul-dlss-labs/taco/db"
 	"github.com/sul-dlss-labs/taco/persistence"
 )
 
 // NewRuntime creates a new application level runtime that encapsulates the shared services for this application
-func NewRuntime() (*Runtime, error) {
-	repository, err := persistence.NewRepository(db.NewConnection())
+func NewRuntime(config *config.Config) (*Runtime, error) {
+	repository, err := persistence.NewRepository(config, db.NewConnection())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This prevents us from having to initialize multiple copies of the configuration (one per service)