### PR TITLE
Use the external identifier service

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,10 +14,10 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  branch = "master"
   name = "github.com/StackExchange/wmi"
   packages = ["."]
   revision = "5d049714c4a64225c3c79a7cf7d02f7fb5b96338"
+  version = "1.0.0"
 
 [[projects]]
   name = "github.com/appleboy/gofight"
@@ -28,8 +28,8 @@
 [[projects]]
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
-  revision = "521b25f4b05fd26bec69d9dedeb8f9c9a83939a8"
-  version = "v8"
+  revision = "ccb8e960c48f04d6935e72476ae4a51028f9e22f"
+  version = "v9"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
@@ -50,6 +50,7 @@
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/sdkio",
     "internal/sdkrand",
     "internal/shareddefaults",
     "private/protocol",
@@ -68,14 +69,14 @@
     "service/s3/s3manager",
     "service/sts"
   ]
-  revision = "9a79087b1148376f4dd860c188c948479e2def3b"
-  version = "v1.13.7"
+  revision = "f0872da8a448f8cb10f4f0c95c2100e4f7356448"
+  version = "v1.13.16"
 
 [[projects]]
   branch = "master"
   name = "github.com/buger/jsonparser"
   packages = ["."]
-  revision = "4be68c93a24430ddf9c33d1380b7042fd3a13424"
+  revision = "2cac668e8456b4284edb0715e17e2af02d3ec993"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -92,8 +93,8 @@
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
-  version = "v1.32.0"
+  revision = "6333e38ac20b8949a8dd68baa3650f4dee8f39f0"
+  version = "v1.33.0"
 
 [[projects]]
   name = "github.com/go-ole/go-ole"
@@ -139,6 +140,7 @@
   name = "github.com/go-openapi/runtime"
   packages = [
     ".",
+    "client",
     "flagext",
     "logger",
     "middleware",
@@ -147,31 +149,31 @@
     "middleware/untyped",
     "security"
   ]
-  revision = "09fac855d8504674b22594470227bd94e5005025"
+  revision = "b1db76181cbf53cf97a98980762a2bbf7cca8a0f"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "f3499b5df53897321d6f5e9c22cf19309d41d3bc"
+  revision = "d8000b5bfbd1147255710505a27c735b6b2ae2ac"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/strfmt"
   packages = ["."]
-  revision = "2a209b09157e641d338e025dc43229ab93d07cc7"
+  revision = "6ba31556a6c60db8615afb9d8eddae7aae15eb48"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  revision = "84f4bee7c0a6db40e3166044c7983c1c32125429"
+  revision = "ceb469cb0fdf2d792f28d771bc05da6c606f55e5"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/validate"
   packages = ["."]
-  revision = "2a09d726370ca256a065c34ba0def99564d620dc"
+  revision = "180bba53b98899f743a112e568bed9e2ef31aa20"
 
 [[projects]]
   name = "github.com/google/uuid"
@@ -210,13 +212,13 @@
     "jlexer",
     "jwriter"
   ]
-  revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
+  revision = "f594efddfa171111dc4349cd6e78e8f61dc7936f"
 
 [[projects]]
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "b4575eea38cca1123ec2dc90c26529b5c5acfcff"
+  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
   name = "github.com/pborman/uuid"
@@ -247,14 +249,24 @@
     "load",
     "mem"
   ]
-  revision = "c432be29ccce470088d07eea25b3ea7e68a8afbb"
-  version = "v2.18.01"
+  revision = "5776ff9c7c5d063d574ef53d740f75c68b448e53"
+  version = "v2.18.02"
 
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/sul-dlss-labs/identifier-service"
+  packages = [
+    "generated/client",
+    "generated/client/operations",
+    "generated/models"
+  ]
+  revision = "aac34c409c4ff56bce354bda3410bb802ecc82e0"
 
 [[projects]]
   name = "github.com/tylerb/graceful"
@@ -278,17 +290,18 @@
   branch = "master"
   name = "github.com/xeipuuv/gojsonschema"
   packages = ["."]
-  revision = "70e59348c29403c606624cd201e79769d6657db8"
+  revision = "8bcffc811467a5f691810420385be6e66b35a317"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = [
     "context",
+    "context/ctxhttp",
     "idna",
     "publicsuffix"
   ]
-  revision = "2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1"
+  revision = "92b859f39abd2d91a854c9f9c4621b2f5054a92d"
 
 [[projects]]
   branch = "master"
@@ -297,10 +310,9 @@
     "unix",
     "windows"
   ]
-  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
+  revision = "d8e400bc7db4870d786864138af681469693d18c"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -319,7 +331,8 @@
     "unicode/rangetable",
     "width"
   ]
-  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   name = "gopkg.in/h2non/baloo.v3"
@@ -360,14 +373,14 @@
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
 
 [[projects]]
-  branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
+  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
+  version = "v2.1.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "683c3591cd58d4422f20a65957d55197e60e44eef31f4ba65b001b7a2f05f7dd"
+  inputs-digest = "26b2aae2a4ec7a1b142f2411c4b074008dc72d42f262d9f8a241b2ffc27bc33d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -80,3 +80,7 @@
 [[constraint]]
   name = "github.com/honeybadger-io/honeybadger-go"
   version = "0.2.1"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/sul-dlss-labs/identifier-service"

--- a/config/config.go
+++ b/config/config.go
@@ -9,14 +9,15 @@ import (
 
 // Config is configuration for the TACO application
 type Config struct {
-	DynamodbEndpoint  string `envVariable:"DYNAMO_DB_ENDPOINT" defaultValue:"localhost:4569"`
-	AwsDisableSSL     bool   `envVariable:"AWS_DISABLE_SSL" defaultValue:"true"`
-	KinesisEndpoint   string `envVariable:"KINESIS_ENDPOINT" defaultValue:"localhost:4568"`
-	ResourceTableName string `envVariable:"RESOURCE_TABLE_NAME" defaultValue:"resources"`
-	DepositStreamName string `envVariable:"DEPOSIT_STREAM_NAME" defaultValue:"deposit"`
-	S3Endpoint        string `envVariable:"S3_ENDPOINT" defaultValue:"localhost:4572"`
-	S3BucketName      string `envVariable:"S3_BUCKET_NAME" defaultValue:"taco-deposited-files"`
-	Port              int    `envVariable:"TACO_PORT" defaultValue:"8080"`
+	DynamodbEndpoint      string `envVariable:"DYNAMO_DB_ENDPOINT" defaultValue:"localhost:4569"`
+	AwsDisableSSL         bool   `envVariable:"AWS_DISABLE_SSL" defaultValue:"true"`
+	KinesisEndpoint       string `envVariable:"KINESIS_ENDPOINT" defaultValue:"localhost:4568"`
+	ResourceTableName     string `envVariable:"RESOURCE_TABLE_NAME" defaultValue:"resources"`
+	DepositStreamName     string `envVariable:"DEPOSIT_STREAM_NAME" defaultValue:"deposit"`
+	S3Endpoint            string `envVariable:"S3_ENDPOINT" defaultValue:"localhost:4572"`
+	S3BucketName          string `envVariable:"S3_BUCKET_NAME" defaultValue:"taco-deposited-files"`
+	Port                  int    `envVariable:"TACO_PORT" defaultValue:"8080"`
+	IdentifierServiceHost string `envVariable:"IDENTIFIER_SERVICE_HOST" defaultValue:""`
 }
 
 // NewConfig creates a new configuration with values from environment variables

--- a/handlers/deposit_file.go
+++ b/handlers/deposit_file.go
@@ -18,13 +18,16 @@ const atContext = "http://sdr.sul.stanford.edu/contexts/taco-base.jsonld"
 const fileType = "http://sdr.sul.stanford.edu/contexts/sdr3-file.jsonld"
 
 // NewDepositFile -- Accepts requests to create a file and pushes it to s3.
-func NewDepositFile(database db.Database, uploader storage.Storage) operations.DepositFileHandler {
-	return &depositFileEntry{database: database, storage: uploader}
+func NewDepositFile(database db.Database, uploader storage.Storage, identifierService identifier.Service) operations.DepositFileHandler {
+	return &depositFileEntry{database: database,
+		storage:           uploader,
+		identifierService: identifierService}
 }
 
 type depositFileEntry struct {
-	database db.Database
-	storage  storage.Storage
+	database          db.Database
+	storage           storage.Storage
+	identifierService identifier.Service
 }
 
 // Handle the deposit file request
@@ -34,7 +37,7 @@ func (d *depositFileEntry) Handle(params operations.DepositFileParams) middlewar
 		return operations.NewDepositFileInternalServerError() // TODO: need a better error
 	}
 
-	id, err := identifier.NewService().Mint()
+	id, err := d.identifierService.Mint()
 	if err != nil {
 		panic(err)
 	}

--- a/handlers/deposit_resource.go
+++ b/handlers/deposit_resource.go
@@ -16,14 +16,20 @@ import (
 )
 
 // NewDepositResource -- Accepts requests to create resource and pushes them to Kinesis.
-func NewDepositResource(database db.Database, stream streaming.Stream, validator validators.ResourceValidator) operations.DepositResourceHandler {
-	return &depositResource{database: database, stream: stream, validator: validator}
+func NewDepositResource(database db.Database, stream streaming.Stream, validator validators.ResourceValidator, identifierService identifier.Service) operations.DepositResourceHandler {
+	return &depositResource{
+		database:          database,
+		stream:            stream,
+		validator:         validator,
+		identifierService: identifierService,
+	}
 }
 
 type depositResource struct {
-	database  db.Database
-	stream    streaming.Stream
-	validator validators.ResourceValidator
+	database          db.Database
+	stream            streaming.Stream
+	validator         validators.ResourceValidator
+	identifierService identifier.Service
 }
 
 // Handle the delete entry request
@@ -37,7 +43,7 @@ func (d *depositResource) Handle(params operations.DepositResourceParams) middle
 		return operations.NewDepositResourceUnprocessableEntity()
 	}
 
-	resourceID, err := identifier.NewService().Mint()
+	resourceID, err := d.identifierService.Mint()
 	if err != nil {
 		panic(err)
 	}

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -7,20 +7,21 @@ import (
 	"github.com/sul-dlss-labs/taco/db"
 	"github.com/sul-dlss-labs/taco/generated/restapi"
 	"github.com/sul-dlss-labs/taco/generated/restapi/operations"
+	"github.com/sul-dlss-labs/taco/identifier"
 	"github.com/sul-dlss-labs/taco/storage"
 	"github.com/sul-dlss-labs/taco/streaming"
 	"github.com/sul-dlss-labs/taco/validators"
 )
 
 // BuildAPI create new service API
-func BuildAPI(database db.Database, stream streaming.Stream, storage storage.Storage) *operations.TacoAPI {
+func BuildAPI(database db.Database, stream streaming.Stream, storage storage.Storage, identifierService identifier.Service) *operations.TacoAPI {
 	api := operations.NewTacoAPI(swaggerSpec())
 	api.RetrieveResourceHandler = NewRetrieveResource(database)
 	depositValidator := validators.NewDepositResourceValidator(database)
-	api.DepositResourceHandler = NewDepositResource(database, stream, depositValidator)
+	api.DepositResourceHandler = NewDepositResource(database, stream, depositValidator, identifierService)
 	updateValidator := validators.NewUpdateResourceValidator(database)
 	api.UpdateResourceHandler = NewUpdateResource(database, stream, updateValidator)
-	api.DepositFileHandler = NewDepositFile(database, storage)
+	api.DepositFileHandler = NewDepositFile(database, storage, identifierService)
 	api.HealthCheckHandler = NewHealthCheck()
 	return api
 }

--- a/handlers/stub_database_test.go
+++ b/handlers/stub_database_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sul-dlss-labs/taco/datautils"
 	"github.com/sul-dlss-labs/taco/db"
+	"github.com/sul-dlss-labs/taco/identifier"
 	"github.com/sul-dlss-labs/taco/storage"
 	"github.com/sul-dlss-labs/taco/streaming"
 )
@@ -20,7 +21,9 @@ func handler(database db.Database, stream streaming.Stream, storage storage.Stor
 	if storage == nil {
 		storage = NewMockStorage()
 	}
-	return BuildAPI(database, stream, storage).Serve(nil)
+
+	identifierService := identifier.NewUUIDService()
+	return BuildAPI(database, stream, storage, identifierService).Serve(nil)
 }
 
 type MockDatabase struct {

--- a/identifier/identifier.go
+++ b/identifier/identifier.go
@@ -1,23 +1,21 @@
 package identifier
 
-import "github.com/google/uuid"
+import (
+	"log"
+
+	"github.com/sul-dlss-labs/taco/config"
+)
 
 // Service the interface for a service that mints identifiers
 type Service interface {
 	Mint() (string, error)
 }
-type uuidIdentifierService struct{}
 
-// NewService creates a new instance of the identifier service
-// TODO: This should create a DRUID service
-func NewService() Service {
-	return &uuidIdentifierService{}
-}
-
-func (d *uuidIdentifierService) Mint() (string, error) {
-	resourceID, err := uuid.NewRandom()
-	if err != nil {
-		return "", err
+func NewService(config *config.Config) Service {
+	if config.IdentifierServiceHost == "" {
+		log.Println("IDENTIFIER_SERVICE_HOST is not set, so using UUID service")
+		return NewUUIDService()
+	} else {
+		return NewRemoteIdentifierService(config)
 	}
-	return resourceID.String(), nil
 }

--- a/identifier/remote_service.go
+++ b/identifier/remote_service.go
@@ -1,0 +1,30 @@
+package identifier
+
+import (
+	"log"
+
+	"github.com/sul-dlss-labs/identifier-service/generated/client"
+	"github.com/sul-dlss-labs/taco/config"
+)
+
+type remoteIdentifierService struct {
+	TransportConfig *client.TransportConfig
+}
+
+// NewRemoteIdentifierService creates a new instance of the identifier service
+func NewRemoteIdentifierService(config *config.Config) Service {
+	host := config.IdentifierServiceHost
+	return &remoteIdentifierService{
+		TransportConfig: client.DefaultTransportConfig().WithHost(host),
+	}
+}
+
+func (d *remoteIdentifierService) Mint() (string, error) {
+	c := client.NewHTTPClientWithConfig(nil, d.TransportConfig)
+	ok, err := c.Operations.MintNewDRUIDS(nil)
+	if err != nil {
+		log.Printf("[ERROR] Unable to get an identifier from the remote service.")
+		return "", err
+	}
+	return string(ok.Payload[0]), nil
+}

--- a/identifier/uuid_service.go
+++ b/identifier/uuid_service.go
@@ -1,0 +1,20 @@
+package identifier
+
+import (
+	"github.com/google/uuid"
+)
+
+type uuidService struct{}
+
+// NewUUIDService creates a new instance of the UUID identifier service
+func NewUUIDService() Service {
+	return &uuidService{}
+}
+
+func (d *uuidService) Mint() (string, error) {
+	resourceID, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+	return resourceID.String(), nil
+}


### PR DESCRIPTION
- [x] Need to figure out how to stub the identifer service for testing.
- [x] depends on https://github.com/sul-dlss-labs/id-proxy-api/pull/31
  - [x] Then need to update the branch in `Gopkg.toml`

The id service is protected behind a feature flag. It won't use it unless you set the `IDENTIFIER_SERVICE_HOST` environment variable, so this could be ready for a merge now. We can change the value of the environment variable when we have the identifier server up.

Fixes #175