### PR TITLE
Handle errors consistently.

### DIFF
--- a/handlers/deposit_file.go
+++ b/handlers/deposit_file.go
@@ -41,15 +41,13 @@ func (d *depositFileEntry) Handle(params operations.DepositFileParams) middlewar
 
 	location, err := d.copyFileToStorage(id, params.Upload)
 	if err != nil {
-		log.Printf("[ERROR] %s", err)
-		return operations.NewDepositFileInternalServerError()
+		panic(err)
 	}
 
 	log.Printf("The location of the file is: %s", *location)
 
 	if err := d.createFileResource(id, params.Upload.Header.Filename); err != nil {
-		log.Printf("[ERROR] %s", err)
-		return operations.NewDepositFileInternalServerError()
+		panic(err)
 	}
 	// TODO: return file location: https://github.com/sul-dlss-labs/taco/issues/160
 	response := map[string]interface{}{"id": id}

--- a/handlers/retrieve_resource_test.go
+++ b/handlers/retrieve_resource_test.go
@@ -13,7 +13,7 @@ func TestRetrieveHappyPath(t *testing.T) {
 	r := gofight.New()
 	repo := NewMockDatabase(&datautils.Resource{})
 	r.GET("/v1/resource/99").
-		Run(handler(repo, NewMockStream(""), nil),
+		Run(handler(repo, nil, nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 				assert.Equal(t, http.StatusOK, r.Code)
 			})
@@ -22,18 +22,19 @@ func TestRetrieveHappyPath(t *testing.T) {
 func TestRetrieveNotFound(t *testing.T) {
 	r := gofight.New()
 	r.GET("/v1/resource/100").
-		Run(handler(NewMockDatabase(nil), NewMockStream(""), nil),
+		Run(handler(NewMockDatabase(nil), nil, nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 				assert.Equal(t, http.StatusNotFound, r.Code)
 			})
 }
 
-// TODO: Error handling
-// func TestRetrieveError(t *testing.T) {
-// 	r := gofight.New()
-// 	r.GET("/v1/resource/100").
-// 		Run(setupFakeRuntime(mockErrorRepo()),
-// 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
-// 				assert.Equal(t, http.StatusUnprocessableEntity, r.Code)
-// 			})
-// }
+func TestRetrieveError(t *testing.T) {
+	r := gofight.New()
+	assert.Panics(t,
+		func() {
+			r.GET("/v1/resource/100").
+				Run(handler(NewMockErrorDatabase(), nil, nil),
+					func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {})
+
+		})
+}

--- a/handlers/stub_database_test.go
+++ b/handlers/stub_database_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sul-dlss-labs/taco/db"
 	"github.com/sul-dlss-labs/taco/storage"
 	"github.com/sul-dlss-labs/taco/streaming"
-	"github.com/sul-dlss-labs/taco/uploaded"
 )
 
 func handler(database db.Database, stream streaming.Stream, storage storage.Storage) http.Handler {
@@ -33,22 +32,6 @@ func NewMockDatabase(record *datautils.Resource) db.Database {
 	return &MockDatabase{CreatedResources: []datautils.Resource{}, record: record}
 }
 
-type MockStream struct {
-	message string
-}
-
-func NewMockStream(message string) streaming.Stream {
-	return &MockStream{message: message}
-}
-
-type MockStorage struct {
-	CreatedFiles []*uploaded.File
-}
-
-func NewMockStorage() storage.Storage {
-	return &MockStorage{CreatedFiles: []*uploaded.File{}}
-}
-
 func (d *MockDatabase) Insert(params datautils.Resource) error {
 	d.CreatedResources = append(d.CreatedResources, params)
 	return nil
@@ -63,16 +46,6 @@ func (d *MockDatabase) Read(id string) (*datautils.Resource, error) {
 
 func (d *MockDatabase) Update(params datautils.Resource) error {
 	return nil
-}
-
-func (s *MockStream) SendMessage(message string) error {
-	return nil
-}
-
-func (s *MockStorage) UploadFile(id string, file *uploaded.File) (*string, error) {
-	s.CreatedFiles = append(s.CreatedFiles, file)
-	path := "s3FileLocation"
-	return &path, nil
 }
 
 type MockErrorDatabase struct {
@@ -91,15 +64,5 @@ func (d *MockErrorDatabase) Update(params datautils.Resource) error {
 }
 
 func (d *MockErrorDatabase) Read(id string) (*datautils.Resource, error) {
-	return nil, errors.New("Broken")
-}
-
-type MockErrorStorage struct{}
-
-func NewMockErrorStorage() storage.Storage {
-	return &MockErrorStorage{}
-}
-
-func (d *MockErrorStorage) UploadFile(id string, file *uploaded.File) (*string, error) {
 	return nil, errors.New("Broken")
 }

--- a/handlers/stub_storage_test.go
+++ b/handlers/stub_storage_test.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"errors"
+
+	"github.com/sul-dlss-labs/taco/storage"
+	"github.com/sul-dlss-labs/taco/uploaded"
+)
+
+type MockStorage struct {
+	CreatedFiles []*uploaded.File
+}
+
+func (s *MockStorage) UploadFile(id string, file *uploaded.File) (*string, error) {
+	s.CreatedFiles = append(s.CreatedFiles, file)
+	path := "s3FileLocation"
+	return &path, nil
+}
+
+func NewMockStorage() storage.Storage {
+	return &MockStorage{CreatedFiles: []*uploaded.File{}}
+}
+
+func NewMockErrorStorage() storage.Storage {
+	return &fakeErroringStorage{}
+}
+
+type fakeErroringStorage struct{}
+
+func (f *fakeErroringStorage) UploadFile(id string, file *uploaded.File) (*string, error) {
+	return nil, errors.New("broken")
+}

--- a/handlers/stub_stream_test.go
+++ b/handlers/stub_stream_test.go
@@ -1,0 +1,15 @@
+package handlers
+
+import "github.com/sul-dlss-labs/taco/streaming"
+
+type MockStream struct {
+	message string
+}
+
+func NewMockStream(message string) streaming.Stream {
+	return &MockStream{message: message}
+}
+
+func (d *MockStream) SendMessage(message string) error {
+	return nil
+}


### PR DESCRIPTION
Handlers should panic on error, we have a middleware that catches panics and issues a 500 Internal Server Error.