### PR TITLE
Use session defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:alpine
 WORKDIR /go/src/github.com/sul-dlss-labs/taco
 COPY . .
 RUN apk update && \
+    apk add bash && \
     apk add --no-cache --virtual .build-deps git && \
     go get -u github.com/golang/dep/cmd/dep && \
     dep ensure && \
@@ -9,10 +10,4 @@ RUN apk update && \
 
 WORKDIR /go/src/github.com/sul-dlss-labs/taco/cmd/tacod
 RUN go install .
-
-
-ENV AWS_ACCESS_KEY_ID 99999
-ENV AWS_SECRET_KEY 99999
-ENV TACO_ENV production
-
 CMD ["tacod"]

--- a/db/db.go
+++ b/db/db.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/sul-dlss-labs/taco/config"
@@ -12,10 +11,12 @@ var db *dynamodb.DynamoDB
 
 // NewConnection creates a new connection to Dynamo using our config
 func NewConnection(config *config.Config) *dynamodb.DynamoDB {
-	return dynamodb.New(session.New(&aws.Config{
-		Region:      aws.String(config.AWSRegion),
-		Credentials: credentials.NewEnvCredentials(),
-		Endpoint:    aws.String(config.DynamodbEndpoint),
-		DisableSSL:  aws.Bool(config.DynamodbDisableSSL),
-	}))
+	sess, err := session.NewSession(&aws.Config{
+		Endpoint:   aws.String(config.DynamodbEndpoint),
+		DisableSSL: aws.Bool(config.DynamodbDisableSSL),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return dynamodb.New(sess)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/go-openapi/runtime"
@@ -22,15 +21,13 @@ type S3BucketStorage struct {
 
 // NewS3Bucket creates a new S3 bucket storage
 func NewS3Bucket(config *config.Config) Storage {
-	sess, err := session.NewSessionWithOptions(session.Options{
-		Config: aws.Config{
-
-			Region:      aws.String(config.AWSRegion),
-			Credentials: credentials.NewEnvCredentials(),
-			Endpoint:    aws.String(config.S3Endpoint),
-			DisableSSL:  aws.Bool(config.S3DisableSSL),
-		},
+	sess, err := session.NewSession(&aws.Config{
+		Endpoint:   aws.String(config.S3Endpoint),
+		DisableSSL: aws.Bool(config.S3DisableSSL),
 	})
+	if err != nil {
+		panic(err)
+	}
 	// This is required for localstack:
 	sess.Config.WithS3ForcePathStyle(true)
 	uploader := s3manager.NewUploader(session.Must(sess, err))

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -21,10 +21,13 @@ type kinesisStream struct {
 
 // NewKinesisStream create a new kinesis stream
 func NewKinesisStream(config *config.Config) Stream {
-	s := session.New(&aws.Config{Region: aws.String(config.AWSRegion),
+	s, err := session.NewSession(&aws.Config{
 		Endpoint:   aws.String(config.KinesisEndpoint),
-		DisableSSL: aws.Bool(config.KinesisDisableSSL)})
-
+		DisableSSL: aws.Bool(config.KinesisDisableSSL),
+	})
+	if err != nil {
+		panic(err)
+	}
 	kc := kinesis.New(s)
 
 	streamName := aws.String(config.DepositStreamName)


### PR DESCRIPTION
`session.NewSession` sets up the default credentials chain (ENV vars first, then shared credentials, then instance or task roles) and allows for us to set the ENV vars in dev and testing but fall back to the task role on the deployed container automagically. I needed to remove the ENV vars from the Dockerfile to allow for this. `session.New` is deprecated as it doesn't pull in that default credentials chain.

Blocked by #231 