### PR TITLE
Move testing documentation out of root README into docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,17 +104,8 @@ $ curl -F "upload=@myfile.pdf;type=application/pdf" http://localhost:8080/v1/fil
 ```
 
 ## Testing
-The unit tests have no external dependencies and can be run like so:
-```shell
-$ go test -v ./... -short
-```
 
-The integration test depends on the taco binary and [Localstack](docs/localstack.md) running.  Once these conditions are met you can run the integration tests using:
-
-```shell
-$ go test test/integration_test.go
-```
-
+Testing and test driven development is closely tied to the entire technology stack. Review the [Testing Guidelines & Framework](./docs/testing.md) documentation.
 
 ## API Code Structure
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ curl -F "upload=@myfile.pdf;type=application/pdf" http://localhost:8080/v1/fil
 
 ## Testing
 
-Testing and test driven development is closely tied to the entire technology stack. Review the [Testing Guidelines & Framework](./docs/testing.md) documentation.
+Testing and test driven development is outlined in the [Testing Guidelines & Framework](./docs/testing.md) documentation.
 
 ## API Code Structure
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 This directory holds an assortment of development documentation. Included are the following:
 
 - [Developer Guidelines](DEVELOPER_GUIDE.MD): Holds information on setting environmental variables for the codebase.
+- [Testing Guidelines & Framework](testing.md): Development guide to writing and running tests.
 - [FAQ](FAQ.md): Frequently Asked Questions on the development of TACO.
 - [Localstack Instructions](localstack.md): Localstack Instructions for stubbing out fake AWS services locally for development.
 - [Benchmarking](benchmarking.md): Preliminary and on-going analysis for benchmarking of TACO.  

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,7 @@
 [Go](https://golang.org) has extensive support for automated [testing](https://golang.org/pkg/testing/) built into the language.
 
 
-Additionally, we utilize the [Gofight](https://github.com/appleboy/gofight) framework to test API handler mock responses.
+Additionally, we utilize the [Gofight](https://github.com/appleboy/gofight) framework to test API handler mock responses and [Baloo](gopkg.in/h2non/baloo.v3) for end-to-end tests.
 
 ## Go Unit Tests
 The unit tests have no external dependencies and can be run like so:
@@ -14,8 +14,9 @@ $ go test -v ./... -short
 ```
 
 ## Go Package Tests
-The package tests are dependent on [Localstack](docs/localstack.md) running as they are testing individual connectivity to
-external services.
+
+_Note: The db package test is dependent on [Localstack](docs/localstack.md) running as they are testing individual connectivity to
+external services._
 
 ```shell
 AWS_REGION=localstack go test -v ./[PACKAGE NAME]/
@@ -37,7 +38,7 @@ $ go test test/integration_test.go
 &awserr.baseError{code:"MissingRegion", message:"could not find region configuration", errs:[]error(nil)}
 ```
 
-This error indicates that the command line aws region key (`AWS_REGION`) are missing.
+This error indicates that the environment variable aws region key (`AWS_REGION`) are missing.
 
 ### Missing AWS Resource
 
@@ -50,5 +51,4 @@ With a corrisponding
 WARNING:localstack.services.dynamodb.dynamodb_listener: Unknown table: resources not found in {}
 ```
 
-Is an indication that the particular [Localstack](docs/localstack.md) resource is missing. Follow the instructions in the document
-to ensure the resource is available.
+Is an indication that the particular [Localstack](docs/localstack.md) dynamobdb table is missing. Follow the instructions in the document to ensure the resource is available.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,54 @@
+# Testing Guidelines & Framework
+
+## Testing Framework
+
+[Go](https://golang.org) has extensive support for automated [testing](https://golang.org/pkg/testing/) built into the language.
+
+
+Additionally, we utilize the [Gofight](https://github.com/appleboy/gofight) framework to test API handler mock responses.
+
+## Go Unit Tests
+The unit tests have no external dependencies and can be run like so:
+```shell
+$ go test -v ./... -short
+```
+
+## Go Package Tests
+The package tests are dependent on [Localstack](docs/localstack.md) running as they are testing individual connectivity to
+external services.
+
+```shell
+AWS_REGION=localstack go test -v ./[PACKAGE NAME]/
+```
+
+## Go Integration Tests
+
+The integration test depends on the taco binary and [Localstack](docs/localstack.md) running.  Once these conditions are met you can run the integration tests using:
+
+```shell
+$ go test test/integration_test.go
+```
+
+## Troubleshooting Common Errors
+
+### Missing Region
+
+```
+&awserr.baseError{code:"MissingRegion", message:"could not find region configuration", errs:[]error(nil)}
+```
+
+This error indicates that the command line aws region key (`AWS_REGION`) are missing.
+
+### Missing AWS Resource
+
+```
+&awserr.requestError{awsError:(*awserr.baseError)(0xc420060a00), statusCode:400, requestID:"8e442552-4370-46d1-8226-73a0db496dcd"}
+```
+
+With a corrisponding
+```
+WARNING:localstack.services.dynamodb.dynamodb_listener: Unknown table: resources not found in {}
+```
+
+Is an indication that the particular [Localstack](docs/localstack.md) resource is missing. Follow the instructions in the document
+to ensure the resource is available.


### PR DESCRIPTION
The first of a few documentation PRs related to #265 and #288

- [x] Moves the existing testing content from README to `docs/testing.md`
- [x] Adds framework introduction to `docs/testing.md`
- [x] Adds package testing instructions to `docs/testing.md`
- [x] Adds link to `docs/testing.md` to `docs/README.md`