### PR TITLE
Deployed container needs certs to hit https endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine as BASE
 WORKDIR /go/src/github.com/sul-dlss-labs/taco
 COPY . .
-RUN apk update && \
+RUN apk update && apk add --no-cache ca-certificates && \
     apk add --no-cache --virtual .build-deps git && \
     go get -u github.com/golang/dep/cmd/dep && \
     dep ensure && \
@@ -10,5 +10,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o api -ldflags "-s" -a -installsuffix cgo
 
 FROM scratch
 EXPOSE 8080
+COPY --from=BASE /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=BASE /go/src/github.com/sul-dlss-labs/taco/api .
 CMD ["./api"]


### PR DESCRIPTION
The current deployed container can't hit its external https endpoints cause it doesn't has an SSL cert needed for handshakes.