### PR TITLE
Add an optional query parameter for version

### DIFF
--- a/generated/restapi/doc.go
+++ b/generated/restapi/doc.go
@@ -13,7 +13,7 @@ TACO, the Stanford Digital Repository (SDR) Management Layer API
     License: Apache 2.0 http://www.apache.org/licenses/LICENSE-2.0.html
 
     Consumes:
-    - application/json
+    - application/json+ld
     - multipart/form-data
 
     Produces:

--- a/generated/restapi/embedded_spec.go
+++ b/generated/restapi/embedded_spec.go
@@ -153,6 +153,12 @@ func init() {
             "name": "ID",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "description": "TACO Resource Version Number.",
+            "name": "version",
+            "in": "query"
           }
         ],
         "responses": {

--- a/generated/restapi/operations/retrieve_resource_parameters.go
+++ b/generated/restapi/operations/retrieve_resource_parameters.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
 	strfmt "github.com/go-openapi/strfmt"
@@ -35,6 +36,10 @@ type RetrieveResourceParams struct {
 	  In: path
 	*/
 	ID string
+	/*TACO Resource Version Number.
+	  In: query
+	*/
+	Version *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -43,8 +48,15 @@ func (o *RetrieveResourceParams) BindRequest(r *http.Request, route *middleware.
 	var res []error
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
 	rID, rhkID, _ := route.Params.GetOK("ID")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qVersion, qhkVersion, _ := qs.GetOK("version")
+	if err := o.bindVersion(qVersion, qhkVersion, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -61,6 +73,20 @@ func (o *RetrieveResourceParams) bindID(rawData []string, hasKey bool, formats s
 	}
 
 	o.ID = raw
+
+	return nil
+}
+
+func (o *RetrieveResourceParams) bindVersion(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	o.Version = &raw
 
 	return nil
 }

--- a/generated/restapi/operations/retrieve_resource_urlbuilder.go
+++ b/generated/restapi/operations/retrieve_resource_urlbuilder.go
@@ -16,6 +16,8 @@ import (
 type RetrieveResourceURL struct {
 	ID string
 
+	Version *string
+
 	_basePath string
 	// avoid unkeyed usage
 	_ struct{}
@@ -53,6 +55,18 @@ func (o *RetrieveResourceURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var version string
+	if o.Version != nil {
+		version = *o.Version
+	}
+	if version != "" {
+		qs.Set("version", version)
+	}
+
+	result.RawQuery = qs.Encode()
 
 	return &result, nil
 }

--- a/generated/restapi/operations/taco_api.go
+++ b/generated/restapi/operations/taco_api.go
@@ -80,7 +80,7 @@ type TacoAPI struct {
 	// It has a default implemention in the security package, however you can replace it for your particular usage.
 	BearerAuthenticator func(string, security.ScopedTokenAuthentication) runtime.Authenticator
 
-	// JSONConsumer registers a consumer for a "application/json" mime type
+	// JSONConsumer registers a consumer for a "application/json+ld" mime type
 	JSONConsumer runtime.Consumer
 	// MultipartformConsumer registers a consumer for a "multipart/form-data" mime type
 	MultipartformConsumer runtime.Consumer

--- a/swagger.json
+++ b/swagger.json
@@ -66,6 +66,12 @@
           "description": "TACO Resource Identifier.",
           "required": true,
           "type": "string"
+        },{
+          "name": "version",
+          "in": "query",
+          "description": "TACO Resource Version Number.",
+          "required": false,
+          "type": "string"
         }],
         "responses": {
           "200": {


### PR DESCRIPTION
This adds an optional version parameter to the query for version. So a retrieve resource will look like:

`http://localhost:8080/v1/resource/269c34f2-e9c2-4019-8a80-5fb59d0ee80e?version=1`

The reason for this is that swagger doesn't support optional path parameters or duplicate paths. So we can't specify `GET /resource/{ID}` AND `GET /resource/{ID}/{version}`.

Refs #276 