### PR TITLE
Add authorization agent to the update handler

### DIFF
--- a/authorization/authorization.go
+++ b/authorization/authorization.go
@@ -8,6 +8,7 @@ import (
 type Service interface {
 	CanCreateResourceOfType(string) bool
 	CanRetrieveResource(*datautils.Resource) bool
+	CanUpdateResource(*datautils.Resource) bool
 }
 
 type dummyAuthorizationService struct {
@@ -24,5 +25,9 @@ func (d *dummyAuthorizationService) CanCreateResourceOfType(resourceType string)
 }
 
 func (d *dummyAuthorizationService) CanRetrieveResource(res *datautils.Resource) bool {
+	return d.agent.Identifier == "lmcrae@stanford.edu"
+}
+
+func (d *dummyAuthorizationService) CanUpdateResource(res *datautils.Resource) bool {
 	return d.agent.Identifier == "lmcrae@stanford.edu"
 }

--- a/generated/restapi/configure_taco.go
+++ b/generated/restapi/configure_taco.go
@@ -68,7 +68,7 @@ func configureAPI(api *operations.TacoAPI) http.Handler {
 	api.RetrieveResourceHandler = operations.RetrieveResourceHandlerFunc(func(params operations.RetrieveResourceParams, principal *authorization.Agent) middleware.Responder {
 		return middleware.NotImplemented("operation .RetrieveResource has not yet been implemented")
 	})
-	api.UpdateResourceHandler = operations.UpdateResourceHandlerFunc(func(params operations.UpdateResourceParams) middleware.Responder {
+	api.UpdateResourceHandler = operations.UpdateResourceHandlerFunc(func(params operations.UpdateResourceParams, principal *authorization.Agent) middleware.Responder {
 		return middleware.NotImplemented("operation .UpdateResource has not yet been implemented")
 	})
 

--- a/generated/restapi/embedded_spec.go
+++ b/generated/restapi/embedded_spec.go
@@ -32,11 +32,6 @@ func init() {
   "paths": {
     "/file": {
       "post": {
-        "security": [
-          {
-            "RemoteUser": []
-          }
-        ],
         "description": "Deposits a new File (binary) into SDR. Will return the SDR identifier for the File resource (aka the metadata object generated and persisted for management of the provided binary).",
         "consumes": [
           "multipart/form-data"
@@ -46,6 +41,11 @@ func init() {
         ],
         "summary": "Deposit New File (binary).",
         "operationId": "depositFile",
+        "security": [
+          {
+            "RemoteUser": []
+          }
+        ],
         "parameters": [
           {
             "type": "file",
@@ -97,11 +97,6 @@ func init() {
     },
     "/resource": {
       "post": {
-        "security": [
-          {
-            "RemoteUser": []
-          }
-        ],
         "description": "Deposits a new resource (Collection, Digital Repository Object, File [metadata only] or subclass of those) into SDR. Will return the SDR identifier for the resource.",
         "consumes": [
           "application/json",
@@ -112,6 +107,11 @@ func init() {
         ],
         "summary": "Deposit New TACO Resource.",
         "operationId": "depositResource",
+        "security": [
+          {
+            "RemoteUser": []
+          }
+        ],
         "parameters": [
           {
             "description": "JSON-LD representation of the resource metadata going into SDR. Needs to fit the SDR 3.0 MAP requirements.",
@@ -150,17 +150,17 @@ func init() {
     },
     "/resource/{ID}": {
       "get": {
-        "security": [
-          {
-            "RemoteUser": []
-          }
-        ],
         "description": "Retrieves the metadata (as JSON-LD following our SDR3 MAP v.1) for an existing TACO resource (Collection, Digital Repository Object, File metadata object [not binary] or subclass of those). The resource is identified by the TACO identifier.",
         "produces": [
           "application/json"
         ],
         "summary": "Retrieve TACO Resource Metadata.",
         "operationId": "retrieveResource",
+        "security": [
+          {
+            "RemoteUser": []
+          }
+        ],
         "parameters": [
           {
             "type": "string",
@@ -230,6 +230,11 @@ func init() {
         ],
         "summary": "Update TACO Resource.",
         "operationId": "updateResource",
+        "security": [
+          {
+            "RemoteUser": []
+          }
+        ],
         "parameters": [
           {
             "type": "string",
@@ -278,17 +283,17 @@ func init() {
     },
     "/status/{ID}": {
       "get": {
-        "security": [
-          {
-            "RemoteUser": []
-          }
-        ],
         "description": "Get the processing status and history for a resource.",
         "produces": [
           "application/json"
         ],
         "summary": "Resource Processing Status.",
         "operationId": "getProcessStatus",
+        "security": [
+          {
+            "RemoteUser": []
+          }
+        ],
         "parameters": [
           {
             "type": "string",

--- a/generated/restapi/operations/taco_api.go
+++ b/generated/restapi/operations/taco_api.go
@@ -55,7 +55,7 @@ func NewTacoAPI(spec *loads.Document) *TacoAPI {
 		RetrieveResourceHandler: RetrieveResourceHandlerFunc(func(params RetrieveResourceParams, principal *authorization.Agent) middleware.Responder {
 			return middleware.NotImplemented("operation RetrieveResource has not yet been implemented")
 		}),
-		UpdateResourceHandler: UpdateResourceHandlerFunc(func(params UpdateResourceParams) middleware.Responder {
+		UpdateResourceHandler: UpdateResourceHandlerFunc(func(params UpdateResourceParams, principal *authorization.Agent) middleware.Responder {
 			return middleware.NotImplemented("operation UpdateResource has not yet been implemented")
 		}),
 

--- a/generated/restapi/operations/update_resource.go
+++ b/generated/restapi/operations/update_resource.go
@@ -9,19 +9,20 @@ import (
 	"net/http"
 
 	middleware "github.com/go-openapi/runtime/middleware"
+	"github.com/sul-dlss-labs/taco/authorization"
 )
 
 // UpdateResourceHandlerFunc turns a function with the right signature into a update resource handler
-type UpdateResourceHandlerFunc func(UpdateResourceParams) middleware.Responder
+type UpdateResourceHandlerFunc func(UpdateResourceParams, *authorization.Agent) middleware.Responder
 
 // Handle executing the request and returning a response
-func (fn UpdateResourceHandlerFunc) Handle(params UpdateResourceParams) middleware.Responder {
-	return fn(params)
+func (fn UpdateResourceHandlerFunc) Handle(params UpdateResourceParams, principal *authorization.Agent) middleware.Responder {
+	return fn(params, principal)
 }
 
 // UpdateResourceHandler interface for that can handle valid update resource params
 type UpdateResourceHandler interface {
-	Handle(UpdateResourceParams) middleware.Responder
+	Handle(UpdateResourceParams, *authorization.Agent) middleware.Responder
 }
 
 // NewUpdateResource creates a new http.Handler for the update resource operation
@@ -48,12 +49,25 @@ func (o *UpdateResource) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 	var Params = NewUpdateResourceParams()
 
+	uprinc, aCtx, err := o.Context.Authorize(r, route)
+	if err != nil {
+		o.Context.Respond(rw, r, route.Produces, route, err)
+		return
+	}
+	if aCtx != nil {
+		r = aCtx
+	}
+	var principal *authorization.Agent
+	if uprinc != nil {
+		principal = uprinc.(*authorization.Agent) // this is really a authorization.Agent, I promise
+	}
+
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
-	res := o.Handler.Handle(Params) // actually handle the request
+	res := o.Handler.Handle(Params, principal) // actually handle the request
 
 	o.Context.Respond(rw, r, route.Produces, route, res)
 

--- a/handlers/update_resource_test.go
+++ b/handlers/update_resource_test.go
@@ -42,6 +42,9 @@ func TestUpdateResourceHappyPath(t *testing.T) {
 	repo := NewMockDatabase(datautils.NewResource(datautils.JSONObject{"id": "99"}))
 
 	r.PATCH("/v1/resource/99").
+		SetHeader(gofight.H{
+			"On-Behalf-Of": "lmcrae@stanford.edu",
+		}).
 		SetHeader(gofight.H{"Content-Type": "application/json"}).
 		SetJSON(updateMessage).
 		Run(handler(repo, nil, nil),
@@ -53,6 +56,9 @@ func TestUpdateResourceHappyPath(t *testing.T) {
 func TestUpdateResourceNotFound(t *testing.T) {
 	r := gofight.New()
 	r.PATCH("/v1/resource/99").
+		SetHeader(gofight.H{
+			"On-Behalf-Of": "lmcrae@stanford.edu",
+		}).
 		SetHeader(gofight.H{"Content-Type": "application/json"}).
 		SetJSON(updateMessage).
 		Run(handler(NewMockDatabase(nil), nil, nil),
@@ -64,6 +70,9 @@ func TestUpdateResourceNotFound(t *testing.T) {
 func TestUpdateInvalidResource(t *testing.T) {
 	r := gofight.New()
 	r.PATCH("/v1/resource/100").
+		SetHeader(gofight.H{
+			"On-Behalf-Of": "lmcrae@stanford.edu",
+		}).
 		SetHeader(gofight.H{"Content-Type": "application/json"}).
 		SetJSON(gofight.D{
 			"id":       "oo000oo0001",
@@ -84,6 +93,9 @@ func TestUpdateInvalidResource(t *testing.T) {
 func TestUpdateResourceEmptyRequest(t *testing.T) {
 	r := gofight.New()
 	r.PATCH("/v1/resource/100").
+		SetHeader(gofight.H{
+			"On-Behalf-Of": "lmcrae@stanford.edu",
+		}).
 		Run(handler(NewMockDatabase(nil), nil, nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 				assert.Equal(t, http.StatusUnprocessableEntity, r.Code)

--- a/handlers/update_resource_test.go
+++ b/handlers/update_resource_test.go
@@ -42,10 +42,7 @@ func TestUpdateResourceHappyPath(t *testing.T) {
 	repo := NewMockDatabase(datautils.NewResource(datautils.JSONObject{"id": "99"}))
 
 	r.PATCH("/v1/resource/99").
-		SetHeader(gofight.H{
-			"On-Behalf-Of": "lmcrae@stanford.edu",
-		}).
-		SetHeader(gofight.H{"Content-Type": "application/json"}).
+		SetHeader(gofight.H{"Content-Type": "application/json", "On-Behalf-Of": "lmcrae@stanford.edu"}).
 		SetJSON(updateMessage).
 		Run(handler(repo, nil, nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
@@ -56,10 +53,7 @@ func TestUpdateResourceHappyPath(t *testing.T) {
 func TestUpdateResourceNotFound(t *testing.T) {
 	r := gofight.New()
 	r.PATCH("/v1/resource/99").
-		SetHeader(gofight.H{
-			"On-Behalf-Of": "lmcrae@stanford.edu",
-		}).
-		SetHeader(gofight.H{"Content-Type": "application/json"}).
+		SetHeader(gofight.H{"Content-Type": "application/json", "On-Behalf-Of": "lmcrae@stanford.edu"}).
 		SetJSON(updateMessage).
 		Run(handler(NewMockDatabase(nil), nil, nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
@@ -70,10 +64,7 @@ func TestUpdateResourceNotFound(t *testing.T) {
 func TestUpdateInvalidResource(t *testing.T) {
 	r := gofight.New()
 	r.PATCH("/v1/resource/100").
-		SetHeader(gofight.H{
-			"On-Behalf-Of": "lmcrae@stanford.edu",
-		}).
-		SetHeader(gofight.H{"Content-Type": "application/json"}).
+		SetHeader(gofight.H{"Content-Type": "application/json", "On-Behalf-Of": "lmcrae@stanford.edu"}).
 		SetJSON(gofight.D{
 			"id":       "oo000oo0001",
 			"@context": "http://example.com", // This is not a valid context

--- a/swagger.json
+++ b/swagger.json
@@ -101,6 +101,9 @@
       "patch": {
         "summary": "Update TACO Resource.",
         "description": "Updates the metadata for an existing TACO resource (Collection, Digital Repository Object, File metadata object [not binary] or subclass of those). Only include the required fields and the fields you wish to have changed. Will return the TACO resource identifier.",
+        "security" : [
+          { "RemoteUser": [] }
+        ],
         "operationId": "updateResource",
         "consumes": ["application/json", "application/json+ld"],
         "produces": ["application/json"],


### PR DESCRIPTION
Adds the remote user check in swagger.json and adds the `CanUpdateResource` method to the auth service stub.

Refs #312 and #314 