### PR TITLE
UpdateResource: Check version and create new resource for new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,21 @@ $ curl -H "Content-Type: application/json" \
 ```
 
 You can then update the resource with a **PATCH** request:
+
+Note: in the example file, the `externalIdentifier` and `identification.identifier` must be set to the value returned from the POST, and
+the `tacoIdentifier` must be set to the value retrieved in the GET
+
+Without changing the version number:
+
 ```shell
 $ curl -X PATCH -H "Content-Type: application/json" \ -d@examples/update_request.json \
--H "On-Behalf-Of: lmcrae@stanford.edu" \ http://localhost:8080/v1/resource/fe1f66a9-5285-4b28-8240-0482c8fff6c7
+-H "On-Behalf-Of: lmcrae@stanford.edu" http://localhost:8080/v1/resource/fe1f66a9-5285-4b28-8240-0482c8fff6c7
+```
+
+With changing the version number:
+```shell
+$ curl -X PATCH -H "Content-Type: application/json" \ -d@examples/update_request_new_version.json \
+-H "On-Behalf-Of: lmcrae@stanford.edu" http://localhost:8080/v1/resource/fe1f66a9-5285-4b28-8240-0482c8fff6c7
 ```
 
 Create an uploaded file by doing:

--- a/datautils/resource.go
+++ b/datautils/resource.go
@@ -136,6 +136,20 @@ func (d *Resource) WithVersion(version int) *Resource {
 	return d
 }
 
+// WithPrecedingVersion sets the precedingVersion to
+// the id passed (of the old version)
+func (d *Resource) WithPrecedingVersion(id string) *Resource {
+	d.JSON["precedingVersion"] = id
+	return d
+}
+
+// WithFollowingVersion sets the followingVersion to
+// the id passed (of the new version)
+func (d *Resource) WithFollowingVersion(id string) *Resource {
+	d.JSON["followingVersion"] = id
+	return d
+}
+
 func contains(s []string, e string) bool {
 	for _, a := range s {
 		if a == e {

--- a/examples/update_request_new_version.json
+++ b/examples/update_request_new_version.json
@@ -6,7 +6,8 @@
     "name": "DOR",
     "sunetID": "DOR"
   },
-  "id": "742a0134-1e20-11e2-979d-022c4a946c80",
+  "externalIdentifier": "druid:bs646cd8717",
+  "tacoIdentifier": "742a0134-1e20-11e2-979d-022c4a946c80",
   "label": "UPDATED: Leon Kolb Collection of Portraits",
   "version": 2,
   "access": {

--- a/examples/update_request_new_version.json
+++ b/examples/update_request_new_version.json
@@ -1,0 +1,41 @@
+{
+  "@context": "http://sdr.sul.stanford.edu/contexts/taco-base.jsonld",
+  "@type": "http://sdr.sul.stanford.edu/models/sdr3-collection.jsonld",
+  "citation": "Leon Kolb Collection of Portraits. https://purl.stanford.edu/bs646cd8717",
+  "depositor": {
+    "name": "DOR",
+    "sunetID": "DOR"
+  },
+  "id": "742a0134-1e20-11e2-979d-022c4a946c80",
+  "label": "UPDATED: Leon Kolb Collection of Portraits",
+  "version": 2,
+  "access": {
+    "access": "world",
+    "copyright": "This work is copyrighted by the creator.",
+    "download": "world",
+    "reuseAndReproductionStatement": "Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu."
+  },
+  "administrative": {
+    "created": "2011-07-05T17:12:18.779Z",
+    "deleted": false,
+    "isDescribedBy": "https://purl.stanford.edu/bs646cd8717.xml",
+    "lastUpdated": "2016-11-04T18:21:45.889Z",
+    "sdrPreserve": true,
+    "remediatedBy": [{
+      "name": "Laura Wilsey",
+      "sunetID": "lauraw15"
+    }]
+  },
+  "identification": {
+    "catkey": "4084372",
+    "identifier": "druid:bs646cd8717",
+    "sourceId": "bib4084372",
+    "sdrUUID": "742a0134-1e20-11e2-979d-022c4a946c80"
+  },
+  "structural": {
+    "hasAgreement": "druid:dd327qr3670",
+    "hasMember": [],
+    "isTargetOf": "",
+    "hasMemberOrders": []
+  }
+}

--- a/handlers/update_resource_test.go
+++ b/handlers/update_resource_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/sul-dlss-labs/taco/datautils"
 )
 
-var updateMessage = gofight.D{
-	"tacoIdentifier":     "77",
+var updateMessageSameVersion = gofight.D{
 	"externalIdentifier": "99",
 	"@context":           "http://sdr.sul.stanford.edu/contexts/taco-base.jsonld",
 	"@type":              "http://sdr.sul.stanford.edu/models/sdr3-object.jsonld",
+	"tacoIdentifier":     "99",
 	"access": gofight.D{
 		"access":   "world",
 		"download": "world",
@@ -23,7 +23,35 @@ var updateMessage = gofight.D{
 		"isDescribedBy": "the_mods.xml",
 		"created":       "2012-10-28T04:13:43.639Z",
 	},
-	"version": 5,
+	"version": 1,
+	"depositor": gofight.D{
+		"name":    "Lynn",
+		"sunetID": "lmcray",
+	},
+	"identification": gofight.D{
+		"identifier": "1234abc",
+		"sdrUUID":    "123888019239",
+	},
+	"structural": gofight.D{
+		"hasAgreement": "yes",
+	},
+	"label": "My updated work"}
+
+var updateMessageNewVersion = gofight.D{
+	"externalIdentifier": "99",
+	"@context":           "http://sdr.sul.stanford.edu/contexts/taco-base.jsonld",
+	"@type":              "http://sdr.sul.stanford.edu/models/sdr3-object.jsonld",
+	"tacoIdentifier":     "99",
+	"access": gofight.D{
+		"access":   "world",
+		"download": "world",
+	},
+	"administrative": gofight.D{
+		"sdrPreserve":   false,
+		"isDescribedBy": "the_mods.xml",
+		"created":       "2012-10-28T04:13:43.639Z",
+	},
+	"version": 2,
 	"depositor": gofight.D{
 		"name":    "Lynn",
 		"sunetID": "lmcray",
@@ -39,14 +67,37 @@ var updateMessage = gofight.D{
 
 func TestUpdateResourceHappyPath(t *testing.T) {
 	r := gofight.New()
-	repo := NewMockDatabase(datautils.NewResource(datautils.JSONObject{"tacoIdentifier": "99"}))
+	repo := NewMockDatabase(datautils.NewResource(datautils.JSONObject{"tacoIdentifier": "99", "version": float64(1), "externalIdentifier": "99"}))
 
 	r.PATCH("/v1/resource/99").
 		SetHeader(gofight.H{"Content-Type": "application/json"}).
-		SetJSON(updateMessage).
+		SetJSON(updateMessageSameVersion).
 		Run(handler(repo, nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 				assert.Equal(t, http.StatusOK, r.Code)
+				assert.Equal(t, 1, len(repo.(*MockDatabase).CreatedResources))
+				resource := repo.(*MockDatabase).CreatedResources[0]
+				assert.Equal(t, 1, resource.Version())
+			})
+}
+
+func TestUpdateResourceNewVersionPath(t *testing.T) {
+	r := gofight.New()
+	repo := NewMockDatabase(datautils.NewResource(datautils.JSONObject{"tacoIdentifier": "99", "version": float64(1), "externalIdentifier": "99"}))
+
+	r.PATCH("/v1/resource/99").
+		SetHeader(gofight.H{"Content-Type": "application/json"}).
+		SetJSON(updateMessageNewVersion).
+		Run(handler(repo, nil),
+			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+				assert.Equal(t, http.StatusOK, r.Code)
+				assert.Equal(t, 2, len(repo.(*MockDatabase).CreatedResources))
+				oldResource := repo.(*MockDatabase).CreatedResources[1]
+				newResource := repo.(*MockDatabase).CreatedResources[0]
+				assert.Equal(t, 1, oldResource.Version())
+				assert.Equal(t, newResource.ID(), oldResource.JSON["followingVersion"])
+				assert.Equal(t, 2, newResource.Version())
+				assert.Equal(t, "99", newResource.JSON["precedingVersion"])
 			})
 }
 
@@ -54,7 +105,7 @@ func TestUpdateResourceNotFound(t *testing.T) {
 	r := gofight.New()
 	r.PATCH("/v1/resource/99").
 		SetHeader(gofight.H{"Content-Type": "application/json"}).
-		SetJSON(updateMessage).
+		SetJSON(updateMessageSameVersion).
 		Run(handler(NewMockDatabase(nil), nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 				assert.Equal(t, http.StatusNotFound, r.Code)


### PR DESCRIPTION
Adds a `verifyPayload` method to update in order to do any required checks against the update payload and the existing resource.

Note: Fixes #394 