### PR TITLE
Add custom Marshal/Unmarshal to support empty lists

### DIFF
--- a/datautils/jsonobject.go
+++ b/datautils/jsonobject.go
@@ -1,6 +1,8 @@
 package datautils
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // JSONObject represents a JSON object.
 type JSONObject map[string]interface{}
@@ -11,10 +13,10 @@ func (d *JSONObject) GetS(key string) string {
 	return (*d)[key].(string)
 }
 
-// GetI returns the int value at key
-func (d *JSONObject) GetI(key string) int {
+// GetI returns the float64 value at key
+func (d *JSONObject) GetF(key string) float64 {
 	d.ensureKeyExists(key)
-	return (*d)[key].(int)
+	return (*d)[key].(float64)
 }
 
 // GetB returns the boolean value at key

--- a/datautils/resource.go
+++ b/datautils/resource.go
@@ -62,7 +62,7 @@ func (d *Resource) ExternalIdentifier() string {
 
 // Version returns the document's version
 func (d *Resource) Version() int {
-	return d.JSON.GetI("version")
+	return int(d.JSON.GetF("version"))
 }
 
 // Type returns the document's type
@@ -132,7 +132,7 @@ func (d *Resource) WithCurrentVersion(flag bool) *Resource {
 
 // WithVersion sets the version
 func (d *Resource) WithVersion(version int) *Resource {
-	d.JSON["version"] = version
+	d.JSON["version"] = float64(version)
 	return d
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/sul-dlss-labs/taco/datautils"
 )
 
@@ -45,7 +44,7 @@ func (d *DynamodbDatabase) query(params *dynamodb.QueryInput) (*datautils.Resour
 
 func respToResource(item map[string]*dynamodb.AttributeValue) (*datautils.Resource, error) {
 	var json datautils.JSONObject
-	if err := dynamodbattribute.UnmarshalMap(item, &json); err != nil {
+	if err := UnmarshalMap(item, &json); err != nil {
 		return nil, err
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -48,9 +48,5 @@ func respToResource(item map[string]*dynamodb.AttributeValue) (*datautils.Resour
 		return nil, err
 	}
 
-	// UnmarshalMap coerces all numbers in AWS to float64.
-	// Force version to be an integer
-	json["version"] = int(json["version"].(float64))
-
 	return datautils.NewResource(json), nil
 }

--- a/db/decode.go
+++ b/db/decode.go
@@ -1,0 +1,235 @@
+package db
+
+import (
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/sul-dlss-labs/taco/datautils"
+)
+
+// A Decoder provides unmarshaling AttributeValues to Go value types.
+type Decoder struct {
+	// Instructs the decoder to decode AttributeValue Numbers as
+	// Number type instead of float64 when the destination type
+	// is interface{}. Similar to encoding/json.Number
+	UseNumber bool
+}
+
+// UnmarshalMap is an alias for Unmarshal which unmarshals from
+// a map of AttributeValues.
+//
+// The output value provided must be a non-nil pointer
+func UnmarshalMap(m map[string]*dynamodb.AttributeValue, out *datautils.JSONObject) error {
+	return NewDecoder().Decode(&dynamodb.AttributeValue{M: m}, out)
+}
+
+// NewDecoder creates a new Decoder with default configuration. Use
+// the `opts` functional options to override the default configuration.
+func NewDecoder(opts ...func(*Decoder)) *Decoder {
+	d := &Decoder{}
+	for _, o := range opts {
+		o(d)
+	}
+
+	return d
+}
+
+// Decode will unmarshal an AttributeValue into a Go value type. An error
+// will be return if the decoder is unable to unmarshal the AttributeValue
+// to the provide Go value type.
+//
+// The output value provided must be a non-nil pointer
+func (d *Decoder) Decode(av *dynamodb.AttributeValue, out *datautils.JSONObject, opts ...func(*Decoder)) error {
+	v := reflect.ValueOf(out)
+	if v.Kind() != reflect.Ptr || v.IsNil() || !v.IsValid() {
+		return &dynamodbattribute.InvalidUnmarshalError{Type: reflect.TypeOf(out)}
+	}
+
+	return d.decode(av, v)
+}
+
+var stringInterfaceMapType = reflect.TypeOf(map[string]interface{}(nil))
+var timeType = reflect.TypeOf(time.Time{})
+
+func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value) error {
+	var u dynamodbattribute.Unmarshaler
+	if av == nil || av.NULL != nil {
+		u, v = indirect(v, true)
+		if u != nil {
+			return u.UnmarshalDynamoDBAttributeValue(av)
+		}
+		return d.decodeNull(v)
+	}
+
+	u, v = indirect(v, false)
+	if u != nil {
+		return u.UnmarshalDynamoDBAttributeValue(av)
+	}
+
+	switch {
+	case len(av.B) != 0:
+		panic("Not implemented B")
+	case av.BOOL != nil:
+		return d.decodeBool(av.BOOL, v)
+	case len(av.BS) != 0:
+		panic("Not implemented BS")
+	case av.L != nil:
+		return d.decodeList(av.L, v)
+	case len(av.M) != 0:
+		return d.decodeMap(av.M, v)
+	case av.N != nil:
+		return d.decodeNumber(av.N, v)
+	case len(av.NS) != 0:
+		panic("Not implemented NS")
+	case av.S != nil:
+		return d.decodeString(av.S, v)
+	case len(av.SS) != 0:
+		panic("Not implemented SS")
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeBool(b *bool, v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Bool, reflect.Interface:
+		v.Set(reflect.ValueOf(*b).Convert(v.Type()))
+	default:
+		return &dynamodbattribute.UnmarshalTypeError{Value: "bool", Type: v.Type()}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeNumber(n *string, v reflect.Value) error {
+	// Default to float64 for all numbers
+	i, err := strconv.ParseFloat(*n, 64)
+	if err != nil {
+		return &dynamodbattribute.UnmarshalTypeError{Value: "number", Type: v.Type()}
+	}
+	v.Set(reflect.ValueOf(i))
+	return nil
+}
+
+func (d *Decoder) decodeList(avList []*dynamodb.AttributeValue, v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Interface:
+		s := make([]interface{}, len(avList))
+		for i, av := range avList {
+			if err := d.decode(av, reflect.ValueOf(&s[i]).Elem()); err != nil {
+				return err
+			}
+		}
+		v.Set(reflect.ValueOf(s))
+		return nil
+	default:
+		return &dynamodbattribute.UnmarshalTypeError{Value: "list", Type: v.Type()}
+	}
+}
+
+func (d *Decoder) decodeMap(avMap map[string]*dynamodb.AttributeValue, v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Map:
+		t := v.Type()
+		if t.Key().Kind() != reflect.String {
+			return &dynamodbattribute.UnmarshalTypeError{Value: "map string key", Type: t.Key()}
+		}
+		if v.IsNil() {
+			v.Set(reflect.MakeMap(t))
+		}
+	case reflect.Struct:
+	case reflect.Interface:
+		v.Set(reflect.MakeMap(stringInterfaceMapType))
+		v = v.Elem()
+	default:
+		return &dynamodbattribute.UnmarshalTypeError{Value: "map", Type: v.Type()}
+	}
+
+	if v.Kind() == reflect.Map {
+		for k, av := range avMap {
+			key := reflect.ValueOf(k)
+			elem := reflect.New(v.Type().Elem()).Elem()
+			if err := d.decode(av, elem); err != nil {
+				return err
+			}
+			v.SetMapIndex(key, elem)
+		}
+	} else if v.Kind() == reflect.Struct {
+		panic("Not implemented struct")
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeNull(v reflect.Value) error {
+	if v.IsValid() && v.CanSet() {
+		v.Set(reflect.Zero(v.Type()))
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeString(s *string, v reflect.Value) error {
+	// To maintain backwards compatibility with ConvertFrom family of methods which
+	// converted strings to time.Time structs
+	if v.Type().ConvertibleTo(timeType) {
+		t, err := time.Parse(time.RFC3339, *s)
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.ValueOf(t).Convert(v.Type()))
+		return nil
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString(*s)
+	case reflect.Interface:
+		// Ensure type aliasing is handled properly
+		v.Set(reflect.ValueOf(*s).Convert(v.Type()))
+	default:
+		return &dynamodbattribute.UnmarshalTypeError{Value: "string", Type: v.Type()}
+	}
+
+	return nil
+}
+
+// indirect will walk a value's interface or pointer value types. Returning
+// the final value or the value a unmarshaler is defined on.
+//
+// Based on the enoding/json type reflect value type indirection in Go Stdlib
+// https://golang.org/src/encoding/json/decode.go indirect func.
+func indirect(v reflect.Value, decodingNull bool) (dynamodbattribute.Unmarshaler, reflect.Value) {
+	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() {
+		v = v.Addr()
+	}
+	for {
+		if v.Kind() == reflect.Interface && !v.IsNil() {
+			e := v.Elem()
+			if e.Kind() == reflect.Ptr && !e.IsNil() && (!decodingNull || e.Elem().Kind() == reflect.Ptr) {
+				v = e
+				continue
+			}
+		}
+		if v.Kind() != reflect.Ptr {
+			break
+		}
+		if v.Elem().Kind() != reflect.Ptr && decodingNull && v.CanSet() {
+			break
+		}
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		if v.Type().NumMethod() > 0 {
+			if u, ok := v.Interface().(dynamodbattribute.Unmarshaler); ok {
+				return u, reflect.Value{}
+			}
+		}
+		v = v.Elem()
+	}
+
+	return nil, v
+}

--- a/db/encode.go
+++ b/db/encode.go
@@ -1,0 +1,288 @@
+package db
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/sul-dlss-labs/taco/datautils"
+)
+
+type emptyOrigError struct{}
+
+// An InvalidMarshalError is an error type representing an error
+// occurring when marshaling a Go value type to an AttributeValue.
+type InvalidMarshalError struct {
+	emptyOrigError
+	msg string
+}
+
+// Error returns the string representation of the error.
+// satisfying the error interface
+func (e *InvalidMarshalError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code(), e.Message())
+}
+
+// Code returns the code of the error, satisfying the awserr.Error
+// interface.
+func (e *InvalidMarshalError) Code() string {
+	return "InvalidMarshalError"
+}
+
+// Message returns the detailed message of the error, satisfying
+// the awserr.Error interface.
+func (e *InvalidMarshalError) Message() string {
+	return e.msg
+}
+
+// MarshalMap converts a datautils.JSONObject to a map of dynamodb.AttributeValue
+// values   suitable for making an insert.
+// This is requred, because the dynamodbattribute.MarshalMap casts empty slices
+// to nil, and we think the empty slice is important.
+// See https://github.com/aws/aws-sdk-go/issues/682 and https://github.com/aws/aws-sdk-go-v2/issues/115
+func MarshalMap(in datautils.JSONObject) (map[string]*dynamodb.AttributeValue, error) {
+	av, err := NewEncoder().Encode(in)
+	if err != nil || av == nil || av.M == nil {
+		return map[string]*dynamodb.AttributeValue{}, err
+	}
+
+	return av.M, nil
+}
+
+// An Encoder provides marshaling Go value types to AttributeValues.
+type Encoder struct {
+	// Empty strings, "", will be marked as NULL AttributeValue types.
+	// Empty strings are not valid values for DynamoDB. Will not apply
+	// to lists, sets, or maps. Use the struct tag `omitemptyelem`
+	// to skip empty (zero) values in lists, sets and maps.
+	//
+	// Enabled by default.
+	NullEmptyString bool
+}
+
+// NewEncoder creates a new Encoder with default configuration. Use
+// the `opts` functional options to override the default configuration.
+func NewEncoder(opts ...func(*Encoder)) *Encoder {
+	e := &Encoder{
+		NullEmptyString: true,
+	}
+	for _, o := range opts {
+		o(e)
+	}
+
+	return e
+}
+
+// Encode will marshal a Go value type to an AttributeValue. Returning
+// the AttributeValue constructed or error.
+func (e *Encoder) Encode(in interface{}) (*dynamodb.AttributeValue, error) {
+	av := &dynamodb.AttributeValue{}
+	if err := e.encode(av, reflect.ValueOf(in)); err != nil {
+		return nil, err
+	}
+
+	return av, nil
+}
+
+func (e *Encoder) encode(av *dynamodb.AttributeValue, v reflect.Value) error {
+	// Handle both pointers and interface conversion into types
+	v = valueElem(v)
+
+	switch v.Kind() {
+	case reflect.Invalid:
+		encodeNull(av)
+	case reflect.Struct:
+		panic("invalid type Struct") // return e.encodeStruct(av, v, fieldTag)
+	case reflect.Map:
+		return e.encodeMap(av, v)
+	case reflect.Slice, reflect.Array:
+		return e.encodeSlice(av, v)
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		// do nothing for unsupported types
+	default:
+		return e.encodeScalar(av, v)
+	}
+
+	return nil
+}
+
+func (e *Encoder) encodeMap(av *dynamodb.AttributeValue, v reflect.Value) error {
+	av.M = map[string]*dynamodb.AttributeValue{}
+	for _, key := range v.MapKeys() {
+		keyName := fmt.Sprint(key.Interface())
+		if keyName == "" {
+			return &InvalidMarshalError{msg: "map key cannot be empty"}
+		}
+
+		elemVal := v.MapIndex(key)
+		elem := &dynamodb.AttributeValue{}
+		err := e.encode(elem, elemVal)
+		if err != nil {
+			return err
+		}
+
+		av.M[keyName] = elem
+	}
+
+	return nil
+}
+
+var byteSliceType = reflect.ValueOf([]byte{}).Type()
+var numberType = reflect.TypeOf(dynamodbattribute.Number(""))
+
+func (e *Encoder) encodeSlice(av *dynamodb.AttributeValue, v reflect.Value) error {
+	switch v.Type().Elem().Kind() {
+	case reflect.Uint8:
+		slice := reflect.MakeSlice(byteSliceType, v.Len(), v.Len())
+		reflect.Copy(slice, v)
+
+		b := slice.Bytes()
+		av.B = append([]byte{}, b...)
+	default:
+		var elemFn func(dynamodb.AttributeValue) error
+
+		// List
+		av.L = make([]*dynamodb.AttributeValue, 0, v.Len())
+		elemFn = func(elem dynamodb.AttributeValue) error {
+			av.L = append(av.L, &elem)
+			return nil
+		}
+
+		if _, err := e.encodeList(v, elemFn); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *Encoder) encodeList(v reflect.Value, elemFn func(dynamodb.AttributeValue) error) (int, error) {
+	count := 0
+	for i := 0; i < v.Len(); i++ {
+		elem := dynamodb.AttributeValue{}
+		err := e.encode(&elem, v.Index(i))
+		if err != nil {
+			return 0, err
+		}
+
+		if err := elemFn(elem); err != nil {
+			return 0, err
+		}
+		count++
+	}
+
+	return count, nil
+}
+
+func (e *Encoder) encodeScalar(av *dynamodb.AttributeValue, v reflect.Value) error {
+	if v.Type() == numberType {
+		s := v.String()
+		av.N = &s
+		return nil
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		av.BOOL = new(bool)
+		*av.BOOL = v.Bool()
+	case reflect.String:
+		if err := e.encodeString(av, v); err != nil {
+			return err
+		}
+	default:
+		// Fallback to encoding numbers, will return invalid type if not supported
+		if err := e.encodeNumber(av, v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *Encoder) encodeNumber(av *dynamodb.AttributeValue, v reflect.Value) error {
+	var out string
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		out = encodeInt(v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		out = encodeUint(v.Uint())
+	case reflect.Float32, reflect.Float64:
+		out = encodeFloat(v.Float())
+	default:
+		return &unsupportedMarshalTypeError{Type: v.Type()}
+	}
+
+	av.N = &out
+
+	return nil
+}
+
+func (e *Encoder) encodeString(av *dynamodb.AttributeValue, v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.String:
+		s := v.String()
+		if len(s) == 0 && e.NullEmptyString {
+			encodeNull(av)
+		} else {
+			av.S = &s
+		}
+	default:
+		return &unsupportedMarshalTypeError{Type: v.Type()}
+	}
+
+	return nil
+}
+
+func encodeInt(i int64) string {
+	return strconv.FormatInt(i, 10)
+}
+func encodeUint(u uint64) string {
+	return strconv.FormatUint(u, 10)
+}
+func encodeFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+func encodeNull(av *dynamodb.AttributeValue) {
+	t := true
+	*av = dynamodb.AttributeValue{NULL: &t}
+}
+
+func valueElem(v reflect.Value) reflect.Value {
+	switch v.Kind() {
+	case reflect.Interface, reflect.Ptr:
+		for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+			v = v.Elem()
+		}
+	}
+
+	return v
+}
+
+// An unsupportedMarshalTypeError represents a Go value type
+// which cannot be marshaled into an AttributeValue and should
+// be skipped by the marshaler.
+type unsupportedMarshalTypeError struct {
+	emptyOrigError
+	Type reflect.Type
+}
+
+// Error returns the string representation of the error.
+// satisfying the error interface
+func (e *unsupportedMarshalTypeError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code(), e.Message())
+}
+
+// Code returns the code of the error, satisfying the awserr.Error
+// interface.
+func (e *unsupportedMarshalTypeError) Code() string {
+	return "unsupportedMarshalTypeError"
+}
+
+// Message returns the detailed message of the error, satisfying
+// the awserr.Error interface.
+func (e *unsupportedMarshalTypeError) Message() string {
+	return "Go value type " + e.Type.String() + " is not supported"
+}

--- a/db/encode_test.go
+++ b/db/encode_test.go
@@ -1,0 +1,26 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/sul-dlss-labs/taco/datautils"
+)
+
+func TestMarshal(t *testing.T) {
+	input := jsonData()
+	result, err := MarshalMap(input)
+	assert.Nil(t, err)
+	// Empty lists should remain a list.
+	assert.NotNil(t, result["structural"].M["hasMember"].L)
+	assert.Equal(t, 0, len(result["structural"].M["hasMember"].L))
+
+	var output datautils.JSONObject
+	err = UnmarshalMap(result, &output)
+	assert.Nil(t, err)
+
+	structural := output.GetObj("structural")
+	// Empty lists should remain a list (not changed to nil)
+	assert.NotNil(t, (*structural)["hasMember"])
+	assert.Equal(t, input, output)
+}

--- a/db/insert.go
+++ b/db/insert.go
@@ -3,13 +3,12 @@ package db
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/sul-dlss-labs/taco/datautils"
 )
 
 // Insert create a row in dynamodb
 func (database *DynamodbDatabase) Insert(resource *datautils.Resource) error {
-	row, err := dynamodbattribute.MarshalMap(resource.JSON)
+	row, err := MarshalMap(resource.JSON)
 
 	if err != nil {
 		return err

--- a/examples/request.json
+++ b/examples/request.json
@@ -31,7 +31,7 @@
   "structural": {
     "hasAgreement": "druid:dd327qr3670",
     "hasMember": [],
-    "isTargetOf": "",
+    "isTargetOf": null,
     "hasMemberOrders": []
   }
 }

--- a/examples/update_request.json
+++ b/examples/update_request.json
@@ -36,7 +36,7 @@
   "structural": {
     "hasAgreement": "druid:dd327qr3670",
     "hasMember": [],
-    "isTargetOf": "",
+    "isTargetOf": null,
     "hasMemberOrders": []
   }
 }

--- a/handlers/deposit_resource_test.go
+++ b/handlers/deposit_resource_test.go
@@ -47,9 +47,9 @@ func TestCreateResourceNoApiKey(t *testing.T) {
 	r := gofight.New()
 	r.POST("/v1/resource").
 		SetJSON(gofight.D{
-			"tacoIdentifier":       "oo000oo0001",
-			"sourceId": "bib12345678",
-			"title":    "My work",
+			"tacoIdentifier": "oo000oo0001",
+			"sourceId":       "bib12345678",
+			"title":          "My work",
 		}).
 		Run(handler(nil, nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
@@ -77,9 +77,9 @@ func TestCreateResourceMissingSourceId(t *testing.T) {
 			"On-Behalf-Of": "lmcrae@stanford.edu",
 		}).
 		SetJSON(gofight.D{
-			"tacoIdentifier":    "oo000oo0001",
-			"@type": "http://sdr.sul.stanford.edu/models/sdr3-object.jsonld",
-			"title": "My work",
+			"tacoIdentifier": "oo000oo0001",
+			"@type":          "http://sdr.sul.stanford.edu/models/sdr3-object.jsonld",
+			"title":          "My work",
 		}).
 		Run(handler(nil, nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
@@ -94,14 +94,14 @@ func TestCreateInvalidResource(t *testing.T) {
 			"On-Behalf-Of": "lmcrae@stanford.edu",
 		}).
 		SetJSON(gofight.D{
-			"tacoIdentifier":       "oo000oo0001",
-			"@context": "http://example.com", // This is not a valid context
-			"@type":    "http://sdr.sul.stanford.edu/models/sdr3-object.jsonld",
-			"access":   "world",
-			"label":    "My work",
-			"preserve": true,
-			"publish":  true,
-			"sourceId": "bib12345678"}).
+			"tacoIdentifier": "oo000oo0001",
+			"@context":       "http://example.com", // This is not a valid context
+			"@type":          "http://sdr.sul.stanford.edu/models/sdr3-object.jsonld",
+			"access":         "world",
+			"label":          "My work",
+			"preserve":       true,
+			"publish":        true,
+			"sourceId":       "bib12345678"}).
 		Run(handler(nil, nil),
 			func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 				assert.Equal(t, http.StatusUnprocessableEntity, r.Code)

--- a/maps/Collection.json
+++ b/maps/Collection.json
@@ -218,7 +218,7 @@
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to the Collection.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "hasMemberOrders": {
           "description": "Provided sequences or orderings of members of the Collection, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).",

--- a/maps/DRO.json
+++ b/maps/DRO.json
@@ -256,7 +256,7 @@
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to the DRO.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "hasMemberOrders": {
           "description": "Provided sequences or orderings of members of the Object, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).",

--- a/maps/DepositCollection.json
+++ b/maps/DepositCollection.json
@@ -226,7 +226,7 @@
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to the Collection.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "hasMemberOrders": {
           "description": "Provided sequences or orderings of members of the Collection, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).",

--- a/maps/DepositDRO.json
+++ b/maps/DepositDRO.json
@@ -264,7 +264,7 @@
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to the DRO.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "hasMemberOrders": {
           "description": "Provided sequences or orderings of members of the Object, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).",

--- a/maps/DepositFile.json
+++ b/maps/DepositFile.json
@@ -173,7 +173,7 @@
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to this File.",
-          "type": "string"
+          "type": ["string", "null"]
         }
       }
     }

--- a/maps/DepositFileset.json
+++ b/maps/DepositFileset.json
@@ -135,7 +135,7 @@
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to this Fileset.",
-          "type": "string"
+          "type": ["string", "null"]
         }
       }
     }

--- a/maps/File.json
+++ b/maps/File.json
@@ -159,7 +159,7 @@
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to this File.",
-          "type": "string"
+          "type": ["string", "null"]
         }
       }
     }

--- a/maps/Fileset.json
+++ b/maps/Fileset.json
@@ -127,7 +127,7 @@
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to this Fileset.",
-          "type": "string"
+          "type": ["string", "null"]
         }
       }
     }

--- a/validators/maps.go
+++ b/validators/maps.go
@@ -208,7 +208,7 @@ var (
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to the Collection.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "hasMemberOrders": {
           "description": "Provided sequences or orderings of members of the Collection, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).",
@@ -451,7 +451,7 @@ var (
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to the DRO.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "hasMemberOrders": {
           "description": "Provided sequences or orderings of members of the Object, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).",
@@ -658,7 +658,7 @@ var (
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to the Collection.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "hasMemberOrders": {
           "description": "Provided sequences or orderings of members of the Collection, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).",
@@ -909,7 +909,7 @@ var (
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to the DRO.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "hasMemberOrders": {
           "description": "Provided sequences or orderings of members of the Object, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).",
@@ -1094,7 +1094,7 @@ var (
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to this File.",
-          "type": "string"
+          "type": ["string", "null"]
         }
       }
     }
@@ -1238,7 +1238,7 @@ var (
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to this Fileset.",
-          "type": "string"
+          "type": ["string", "null"]
         }
       }
     }
@@ -1414,7 +1414,7 @@ var (
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to this File.",
-          "type": "string"
+          "type": ["string", "null"]
         }
       }
     }
@@ -1550,7 +1550,7 @@ var (
         },
         "isTargetOf": {
           "description": "An Annotation instance that applies to this Fileset.",
-          "type": "string"
+          "type": ["string", "null"]
         }
       }
     }


### PR DESCRIPTION
This makes it possible to round trip our data without loosing empty
lists. Note, dynamodb doesn't support empty strings, and these changes
do nothing to work around that.

Fixes #387

See: https://github.com/aws/aws-sdk-go/issues/682