### PR TITLE
Add isDescribedBy to example request.json

### DIFF
--- a/examples/request.json
+++ b/examples/request.json
@@ -17,6 +17,7 @@
   "administrative": {
     "deleted": false,
     "sdrPreserve": true,
+    "isDescribedBy": "https://purl.stanford.edu/bs646cd8717.xml",
     "remediatedBy": [
       {
         "name": "Laura Wilsey",


### PR DESCRIPTION
This just adds the `isDescribedBy` property to our example/request.json in order to round trip demo data for update.