### PR TITLE
Remove lastUpdated from update examples

### DIFF
--- a/examples/update_request.json
+++ b/examples/update_request.json
@@ -20,7 +20,6 @@
     "created": "2011-07-05T17:12:18.779Z",
     "deleted": false,
     "isDescribedBy": "https://purl.stanford.edu/bs646cd8717.xml",
-    "lastUpdated": "2016-11-04T18:21:45.889Z",
     "sdrPreserve": true,
     "remediatedBy": [{
       "name": "Laura Wilsey",

--- a/examples/update_request_new_version.json
+++ b/examples/update_request_new_version.json
@@ -20,7 +20,6 @@
     "created": "2011-07-05T17:12:18.779Z",
     "deleted": false,
     "isDescribedBy": "https://purl.stanford.edu/bs646cd8717.xml",
-    "lastUpdated": "2016-11-04T18:21:45.889Z",
     "sdrPreserve": true,
     "remediatedBy": [{
       "name": "Laura Wilsey",


### PR DESCRIPTION
After #414, this removes `lastUpdated` from the update_example files so we don't override anything.