### PR TITLE
Refactor circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,12 @@
+# define often used filter
+filter_on_master_ignore_tags: &filter_on_master_ignore_tags
+  filters:
+    branches:
+      only: master
+    tags:
+      ignore: /.*/
+
+
 version: 2
 jobs:
   run_unit_tests:
@@ -124,31 +133,15 @@ workflows:
   deploy_master_to_demo:
     jobs:
       - run_unit_tests:
-          filters:
-            branches:
-              only: master
-            tags:
-              ignore: /.*/
+          <<: *filter_on_master_ignore_tags
       - run_e2e_tests:
-          filters:
-            branches:
-              only: master
-            tags:
-              ignore: /.*/
+          <<: *filter_on_master_ignore_tags
       - register_image:
           requires:
             - run_unit_tests
             - run_e2e_tests
-          filters:
-            branches:
-              only: master
-            tags:
-              ignore: /.*/
+          <<: *filter_on_master_ignore_tags
       - deploy_to_demo:
           requires:
             - register_image
-          filters:
-            branches:
-              only: master
-            tags:
-              ignore: /.*/
+          <<: *filter_on_master_ignore_tags


### PR DESCRIPTION
Hi guys

I reading into circle-ci configuration and stumbled upon the yaml anchor syntax. I feel like it would simplify a big config if used wisely :)

See https://discuss.circleci.com/t/using-defaults-syntax-in-config-yaml-aka-yaml-anchors/16168/2
or the doc example in https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs