### PR TITLE
Instead of installing python on a go image, use a python image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,16 +59,11 @@ jobs:
             docker push suldlss/taco:latest
 
   deploy_to_demo:
-    docker:
-      - image: circleci/golang:latest
-    working_directory: /go/src/github.com/sul-dlss-labs/taco
+    docker: # NOT the default (awscli is python-based)
+      - image: circleci/python:3.7-stretch-node-browsers
+    working_directory: ~
     steps:
-      - run:
-          name: Install AWS CLI
-          command: |
-            sudo apt-get install -y python-pip libyaml-dev python-dev jq
-            sudo pip install awscli
-      - checkout
+      - run: sudo pip install awscli
       - run:
           name: Register Task & Update Service (demo)
           command: |


### PR DESCRIPTION
Thanks to circle's composition of the underlying image, we also don't have to install `jq`, `libyaml`, `pip`, etc.  They are already available on the (local-to-circle) cached image.  The only unique requirement is `awscli`.

Note: doesn't even require `checkout` because nothing involves the actual app code!

The ability to use different images for different "jobs" in Circle is a major strength. Here's where we applied this strategy in sinopia:
https://github.com/LD4P/sinopia_profile_editor/pull/123/files#diff-1d37e48f9ceff6d8030570cd36286a61R81

This change cuts as much as half the execution time off the "deploy_to_demo" job, and gives the Circle config a more tightly defined responsibility.